### PR TITLE
Fix permissions

### DIFF
--- a/examples/pod-with-security-context.yaml
+++ b/examples/pod-with-security-context.yaml
@@ -7,7 +7,9 @@ metadata:
 spec:
   containers:
     - name: test
-      image: busybox
+      # Jenkins image used for illustration purposes because it has a user
+      # with uid=1000 and gid=1000 that matches the specified security context
+      image: jenkins/jenkins
       command:
         - /config/test.sh
       volumeMounts:
@@ -39,6 +41,7 @@ metadata:
 data:
   test.sh: |
     #!/bin/sh
+    id
     ls -al /test && \
     echo 'Hello from local-path-test' && \
     cp /config/text.txt /test/test.txt && \

--- a/provisioner.go
+++ b/provisioner.go
@@ -186,7 +186,7 @@ func (p *LocalPathProvisioner) Provision(opts pvController.VolumeOptions) (*v1.P
 
 	createCmdsForPath := []string{
 		"mkdir",
-		"-m", "0770",
+		"-m", "0777",
 		"-p",
 	}
 	if err := p.createHelperPod(ActionTypeCreate, createCmdsForPath, name, path, node.Name); err != nil {


### PR DESCRIPTION
This is a follow-up PR for #7, since https://github.com/rancher/local-path-provisioner/commit/3256bdf61b14c6b7e517ede0f56cfebeaf28e616, unfortunately, did not fully fix the issue.

The example I supplied is not ideal. It works with your fix because it uses Busybox which doesn't have group 1000 so the user runs with gid=0. I added `id` to the script which prints the following:

`uid=1000 gid=0(root) groups=0(root),1000`

Now, when I use an image that actually has a user with uid=1000, gid=1000, such as `jenkins/jenkins` it doesn't work because the user does not belong to group 0 in this case:

`uid=1000(jenkins) gid=1000(jenkins) groups=1000(jenkins)`

This fixes the issue using `0777` as Minikube does.