### PR TITLE
use the correct string for namespace env

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ var (
 	EnvProvisionerName     = "PROVISIONER_NAME"
 	DefaultProvisionerName = "rancher.io/local-path"
 	FlagNamespace          = "namespace"
-	EnvNamespace           = "NAMESPACE"
+	EnvNamespace           = "POD_NAMESPACE"
 	DefaultNamespace       = "local-path-storage"
 	FlagHelperImage        = "helper-image"
 	EnvHelperImage         = "HELPER_IMAGE"


### PR DESCRIPTION
When deploying this provisioner in non-default namespace, this provisioning fails with an message about missing local-path-storage. 

As per the deployment file, Namespace is passed using the string POD_NAMESPACE.  (https://github.com/rancher/local-path-provisioner/blob/master/deploy/local-path-storage.yaml#L75)

This PR is to correct the variable name used for fetching the namespace.