### PR TITLE
build and packaging updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+*dapper*
+!Dockerfile.dapper
+bin/

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -19,8 +19,8 @@ RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
-RUN wget -O - https://storage.googleapis.com/golang/go1.11.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get github.com/rancher/trash && go get github.com/golang/lint/golint
+RUN wget -O - https://storage.googleapis.com/golang/go1.12.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local
+RUN go get github.com/rancher/trash && go get golang.org/x/lint/golint
 
 ENV DAPPER_SOURCE /go/src/github.com/rancher/local-path-provisioner
 ENV DAPPER_OUTPUT ./bin

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,8 +1,5 @@
-FROM ubuntu:16.04
+FROM alpine:latest
 
-RUN apt-get update && apt-get install -y curl vim nfs-common iproute dnsutils iputils-ping telnet
+COPY bin /bin
 
-COPY bin /usr/local/sbin/
-
-VOLUME /usr/local/sbin
-CMD ["local-path-provisioner"]
+ENTRYPOINT ["/bin/local-path-provisioner"]

--- a/scripts/build
+++ b/scripts/build
@@ -5,5 +5,5 @@ cd $(dirname $0)/..
 VERSION=${VERSION:-$(./scripts/version)}
 
 mkdir -p bin
-[ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s"
+[ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s -w"
 CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/local-path-provisioner


### PR DESCRIPTION
## Changes

1. Update Dockerfile.dapper to install Go 1.12, separate go gets for better image layer caching
2. replace ubuntu image with simple alpine base image
3. add linker flag -w for smaller binary
4. gitignore some generated files

I've tested this in a Vagrant box and it seems to work fine. Since the binary was built with CGO_ENABLED=0 already there was no need for anything else at runtime. I initially tested with `FROM scratch` but that failed since `/tmp` didn't exist (for logs), so I switched to just plain `alpine:latest`.

The Docker image goes down from ~320MB (v0.0.5) to ~30MB :smile: 