### PR TITLE
working: multi-arch-images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 *dapper*
 !Dockerfile.dapper
 bin/
+
+# generated files
+Dockerfile.gen
+push.sh

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,32 +1,33 @@
-FROM ubuntu:16.04
-# FROM arm=armhf/ubuntu:16.04
+FROM golang:1.11.4
+# FROM arm=golang:1.11.4
 
-ARG DAPPER_HOST_ARCH=amd64
+# this syntax, as a comment, on the line after FROM is special trigger for dapper...
+# FROM arm=armhf/ubuntu:16.04
+# - https://github.com/rancher/dapper/blob/c6a73fd4ef00cf68d251f9f6bff3fea3d319661b/file/file.go#L423
+
+env ARCH amd64
+
 ARG http_proxy
 ARG https_proxy
-ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 
 RUN apt-get update && \
-    apt-get install -y gcc ca-certificates git wget curl vim less file python-tox python-dev && \
-    rm -f /bin/sh && ln -s /bin/bash /bin/sh
+    apt-get install -y apt-transport-https ca-certificates
 
-ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
-    DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
-    DOCKER_URL_arm64=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm64 \
-    DOCKER_URL=DOCKER_URL_${ARCH}
+RUN wget -O - https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+    echo "deb [arch=${ARCH}] https://download.docker.com/linux/ubuntu xenial stable" >> /etc/apt/sources.list && \
+    apt-get update && \
+    cat /etc/apt/sources.list
+	
+RUN apt-get update && \
+    apt-get install -y 'docker-ce=5:18.09.1~3-0~ubuntu-xenial' bash git jq
 
-RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
-
-ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
-    GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-
-RUN wget -O - https://storage.googleapis.com/golang/go1.12.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local
 RUN go get github.com/rancher/trash && go get golang.org/x/lint/golint
 
+ENV DOCKER_CLI_EXPERMENTAL enabled
 ENV DAPPER_SOURCE /go/src/github.com/rancher/local-path-provisioner
 ENV DAPPER_OUTPUT ./bin
 ENV DAPPER_DOCKER_SOCKET true
-ENV DAPPER_ENV IMAGE REPO VERSION TAG
+ENV DAPPER_ENV IMAGE REPO VERSION TAG CROSS
 ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
 ENV HOME ${DAPPER_SOURCE}
 WORKDIR ${DAPPER_SOURCE}

--- a/README.md
+++ b/README.md
@@ -172,6 +172,28 @@ To uninstall, execute:
 kubectl delete -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
 ```
 
+## Building from source
+
+To build binaries for all supported architectures
+```
+$ CROSS=1 make
+```
+The compiled binaries are written to `./bin` with filenames like `./bin/local-path-provisioner-linux-armv6`.
+
+You will need a locally installed copy of the `manifest-tool`
+https://github.com/estesp/manifest-tool, in order to push the
+resulting docker images.
+
+To process the compiled binaries into per-arch and assemble the final multi-arch image, run:
+```
+$ make multi-arch-images
+```
+
+At the end of the `make` output are two inline files, `manifest.yaml`
+and `push.sh`.  Copy each of them from the stderr/stdout to their
+respective filenames, and then run `source push.sh` to push the
+individual arch images and create the final multi-arch image.
+
 ## License
 
 Copyright (c) 2014-2018  [Rancher Labs, Inc.](http://rancher.com/)

--- a/scripts/build
+++ b/scripts/build
@@ -5,5 +5,34 @@ cd $(dirname $0)/..
 VERSION=${VERSION:-$(./scripts/version)}
 
 mkdir -p bin
-[ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s -w"
-CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o bin/local-path-provisioner
+
+if [ "$CROSS" = 1 ]; then
+    ## LINUX
+    
+    # # ppc64le
+    # CGO_ENABLED=0 GOARCH=ppc64le go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o ./bin/local-path-provisioner-Linux-ppc64le
+
+    # arm v6
+    CGO_ENABLED=0 GOARCH=arm GOARM=6 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o ./bin/local-path-provisioner-linux-armv6
+
+    # arm v7
+    CGO_ENABLED=0 GOARCH=arm GOARM=7 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o ./bin/local-path-provisioner-linux-armv7
+
+    # arm64
+    CGO_ENABLED=0 GOARCH=arm64 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o ./bin/local-path-provisioner-linux-arm64
+
+    # amd64
+    CGO_ENABLED=0 GOARCH=amd64 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o ./bin/local-path-provisioner-linux-amd64
+    
+    # # DARWIN
+    # CGO_ENABLED=0 GOOS=darwin go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o ./bin/local-path-provisioner-darwin-x86_64
+
+    # # WINDOWS
+    # CGO_ENABLED=0 GOOS=windows go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o ./bin/local-path-provisioner-Windows-x86_64
+
+else
+    [ "$(uname)" != "Darwin" ] && LINKFLAGS="-extldflags -static -s -w"
+    CGO_ENABLED=0 go build -ldflags "-X main.VERSION=$VERSION $LINKFLAGS" -o ./bin/local-path-provisioner
+
+    echo Built ./bin/local-path-provisioner
+fi

--- a/scripts/ci
+++ b/scripts/ci
@@ -7,8 +7,3 @@ cd $(dirname $0)
 ./validate
 ./test -cover
 ./package
-
-image=`cat ../bin/latest_image`
-
-echo
-echo Longhorn Manager image: ${image}

--- a/scripts/multi-arch-images
+++ b/scripts/multi-arch-images
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -ex
+
+IMAGES=
+REPO=${REPO:-rancher}
+
+cd $(dirname $0)/..
+
+. ./scripts/version
+VERSION="${VER}"  # apparently, from rancher repo to repo, this script can't pick a common output var
+
+# create an ephemeral push script
+echo '#!/bin/bash' >push.sh
+chmod +x push.sh
+
+# create an ephemeral manifest file
+echo image: ${REPO}/local-path-provisioner:${VERSION} > manifest.yaml
+echo manifests: >> manifest.yaml
+
+while read HASH OS VARIANT ARCH; do
+    BIN_ARCH=${ARCH}
+    case ${OS}-${BIN_ARCH} in
+        Darwin-x86_64)
+            ;;
+        linux-arm)
+            [[ ${VARIANT} == v6 ]] && BIN_ARCH=armv6
+            [[ ${VARIANT} == v7 ]] && BIN_ARCH=armv7
+            ;;
+        linux-amd64)
+            ;;
+        linux-arm64)
+            VARIANT=null
+            ;;
+        linux-386|linux-ppc64le|linux-s390x)
+            continue ;;  # skips these ARCH.  Are these platforms supported yet?
+        *)
+            echo ARCH $BIN_ARCH not found.  This is a problem.
+            exit 1
+            ;;
+    esac
+
+    cat > Dockerfile.gen << EOF
+FROM alpine@${HASH}
+COPY bin/local-path-provisioner-${OS}-${BIN_ARCH} /usr/local/bin/local-path-provisioner
+EOF
+    docker build -f Dockerfile.gen -t ${REPO}/local-path-provisioner:${VERSION}-${BIN_ARCH} .
+
+    # add to list of images to push
+    echo docker push ${REPO}/local-path-provisioner:${VERSION}-${BIN_ARCH} >> push.sh
+
+    # handle lack of useful VARIANT template handler when VARIANT is null (jq emits 'null' for us),
+    # cf. https://github.com/estesp/manifest-tool/pull/72
+    case "${VARIANT}" in
+        null)
+            echo "- image: ${REPO}/local-path-provisioner:${VERSION}-${BIN_ARCH}"
+            echo "  platform:"
+            echo "    architecture: ${ARCH}"
+            echo "    os: ${OS}"
+            ;;
+        *)
+            echo "- image: ${REPO}/local-path-provisioner:${VERSION}-${BIN_ARCH}"
+            echo "  platform:"
+            echo "    architecture: ${ARCH}"
+            echo "    variant: ${VARIANT}"
+            echo "    os: ${OS}"
+            ;;
+    esac >> manifest.yaml
+
+done <<< $(DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect alpine:3.9 | jq -r '.manifests[] | "\(.digest) \(.platform.os) \(.platform.variant) \(.platform.architecture)"')
+
+echo '#######' manifest.yaml
+cat ./manifest.yaml
+echo '#######' manifest.yaml
+
+echo manifest-tool push from-spec manifest.yaml >> push.sh
+
+echo '#######' push.sh
+cat ./push.sh
+echo '#######' push.sh
+echo run ./push.sh
+

--- a/scripts/package
+++ b/scripts/package
@@ -3,24 +3,5 @@ set -e
 
 cd $(dirname $0)/..
 
-ARCH=${ARCH:-amd64}
-SUFFIX=""
-[ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
-
-export VERSION=${VERSION:-$(./scripts/version)}
-
-TAG=${TAG:-${VERSION}${SUFFIX}}
-REPO=${REPO:-rancher}
-IMAGE=${IMAGE:-${REPO}/local-path-provisioner:${TAG}}
-
-if [ ! -e ./bin/local-path-provisioner ]; then
-    ./scripts/build
-fi
-
-cp -a ./bin ./package/
-trap 'rm -rf ./package/bin' exit
-docker build -t ${IMAGE} ./package
-
-echo Built ${IMAGE}
-
-echo ${IMAGE} > ./bin/latest_image
+mkdir -p dist/artifacts
+cp -r bin/local-path-provisioner* dist/artifacts


### PR DESCRIPTION
This has been a very interesting area of docker to learn about.
Hopefully this helps folks get more things running on ARM and other platforms.

I copied the basic multi-arch build structure from https://github.com/rancher/dapper 
along with a couple of their `scripts/*`.

I'm not certain the `go build ... -o binary.arch` suffixes in the `scripts/build` I included in this PR are 100% correct.

I chose these so they match the `arch`+`variant` names associated with the current `alpine` manifest,  (read: not the same as the bin_arch names used in https://github.com/rancher/dapper/blob/master/scripts/build .)

Also,
It looked like the `multi-arch-images` `make` target in `rancher/dapper` was being manually called -- as well as the resulting `push.sh` it emitted... so I'm not sure where/how the CI pipelines build and push the multi-arch images... ?

I'm not sure if `dapper` handles exposing files created in containers back to the host, but there is now a `manifest.yaml` file that gets created and should be fed to the `push.sh` script which invokes `manifest-tool`.

If there's a better way, please let me know, or maintainers can push more commits to this branch.

Relates to #12 