### PR TITLE
should specify the namespace for pvc

### DIFF
--- a/examples/pvc.yaml
+++ b/examples/pvc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: local-path-pvc
+  namespace: default
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
We should specify the namespace for pvc, or users who use kube-ns will get in trouble.
(The pod has specified the namespace.)