### PR TITLE
support deployment on air-gap

### DIFF
--- a/deploy/local-path-storage.yaml
+++ b/deploy/local-path-storage.yaml
@@ -61,7 +61,7 @@ spec:
       containers:
       - name: local-path-provisioner
         image: rancher/local-path-provisioner:v0.0.9
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
         - local-path-provisioner
         - --debug


### PR DESCRIPTION
on air-gap mode if you use ```imagePullPolicy: Always``` kubernetes will try to downlod the image even there is no any internet connection. therefor if we will use ```imagePullPolicy: IfNotPresent``` if the image was pre-loaded it will work

please consider to confirm this PR to support air-gap

