### PR TITLE
Add kustomization support for deployments

### DIFF
--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - local-path-storage.yaml


### PR DESCRIPTION
To ease deployments using Kustomize.io now builtin with `kubectl >=v1.14`, a file has to be added to the deploy dir.

By adding `kustomization.yaml` one can define the Github repository as a remote base, which very much simplifies deployments:

```
---
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

bases:
  - ../demo
  - github.com/rancher/local-path-provisioner/deploy

patches:
  - patch-pvc-k3s.yaml
```