### PR TITLE
Fix time.Tick leak

### DIFF
--- a/provisioner.go
+++ b/provisioner.go
@@ -119,9 +119,11 @@ func (p *LocalPathProvisioner) refreshConfig() error {
 
 func (p *LocalPathProvisioner) watchAndRefreshConfig() {
 	go func() {
+		ticker := time.NewTicker(ConfigFileCheckInterval)
+		defer ticker.Stop()
 		for {
 			select {
-			case <-time.Tick(ConfigFileCheckInterval):
+			case <-ticker.C:
 				if err := p.refreshConfig(); err != nil {
 					logrus.Errorf("failed to load the new config file: %v", err)
 				}


### PR DESCRIPTION
https://golang.org/pkg/time/#Tick

> While Tick is useful for clients that have no need to shut down the Ticker, be aware that without a way to shut it down the underlying Ticker cannot be recovered by the garbage collector; it "leaks".

It seems to fix high CPU usage issue. (#73)