### PR TITLE
OpenShift support - allow helper container to run in privileged mode for OCP

### DIFF
--- a/deploy/local-path-storage.yaml
+++ b/deploy/local-path-storage.yaml
@@ -100,7 +100,8 @@ data:
                         "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
                         "paths":["/opt/local-path-provisioner"]
                 }
-                ]
+                ],
+                "privilegedHelper": false
         }
   setup: |-
         #!/bin/sh

--- a/provisioner.go
+++ b/provisioner.go
@@ -57,6 +57,7 @@ type NodePathMapData struct {
 
 type ConfigData struct {
 	NodePathMap []*NodePathMapData `json:"nodePathMap,omitempty"`
+	PrivilegedHelper bool `json:"privilegedHelper"`
 }
 
 type NodePathMap struct {
@@ -318,6 +319,7 @@ func (p *LocalPathProvisioner) createHelperPod(action ActionType, cmdsForPath []
 	}
 
 	hostPathType := v1.HostPathDirectoryOrCreate
+	privileged := p.configData.PrivilegedHelper
 	helperPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      string(action) + "-" + name,
@@ -335,6 +337,8 @@ func (p *LocalPathProvisioner) createHelperPod(action ActionType, cmdsForPath []
 				{
 					Name:    "local-path-" + string(action),
 					Image:   p.helperImage,
+					SecurityContext: &v1.SecurityContext{ 
+						Privileged: &privileged },
 					Command: append(cmdsForPath, filepath.Join("/data/", volumeDir)),
 					VolumeMounts: []v1.VolumeMount{
 						{

--- a/provisioner.go
+++ b/provisioner.go
@@ -56,8 +56,8 @@ type NodePathMapData struct {
 }
 
 type ConfigData struct {
-	NodePathMap []*NodePathMapData `json:"nodePathMap,omitempty"`
-	PrivilegedHelper bool `json:"privilegedHelper"`
+	NodePathMap      []*NodePathMapData `json:"nodePathMap,omitempty"`
+	PrivilegedHelper bool               `json:"privilegedHelper"`
 }
 
 type NodePathMap struct {
@@ -335,10 +335,10 @@ func (p *LocalPathProvisioner) createHelperPod(action ActionType, cmdsForPath []
 			},
 			Containers: []v1.Container{
 				{
-					Name:    "local-path-" + string(action),
-					Image:   p.helperImage,
-					SecurityContext: &v1.SecurityContext{ 
-						Privileged: &privileged },
+					Name:  "local-path-" + string(action),
+					Image: p.helperImage,
+					SecurityContext: &v1.SecurityContext{
+						Privileged: &privileged},
 					Command: append(cmdsForPath, filepath.Join("/data/", volumeDir)),
 					VolumeMounts: []v1.VolumeMount{
 						{


### PR DESCRIPTION
The local-path-provisioner does not work with Openshift, even after creating all possible security contexts. While debugging the issue, I found that the root cause is the helper container. It need to run in privileged mode so that it can create directories in the base path for each container needing PV.
This change helps with that. There is a new flag added to config.json called "privilegedHelper". By default it is set to false (for normal Kubernetes, it doesn't need privileged mode). For OCP, this must be set to true and with right security contexts, the provisioner works fine on OCP. Tested with OCP 4.3 and 4.4.
(please note, I can't do helm changes, if someone can contribute that, it will be great )