### PR TITLE
Add log entry upon helper pod creation

### DIFF
--- a/provisioner.go
+++ b/provisioner.go
@@ -387,6 +387,7 @@ func (p *LocalPathProvisioner) createHelperPod(action ActionType, cmdsForPath []
 
 	// If it already exists due to some previous errors, the pod will be cleaned up later automatically
 	// https://github.com/rancher/local-path-provisioner/issues/27
+	logrus.Infof("create the helper pod %s into %s", helperPod.Name, p.namespace)
 	_, err = p.kubeClient.CoreV1().Pods(p.namespace).Create(helperPod)
 	if err != nil && !k8serror.IsAlreadyExists(err) {
 		return err


### PR DESCRIPTION
This PR proposed adding a log entry at info level to help with cases where the pod creation times out mostly due to the fact it can't pull the helper image, for any reason, but listing pods won't really show anything. On an air-tight environment where you can't pull images from an external registry, it's useful to see that the controller is attempting to created the helper image, be for creating or deleting a volume.