### PR TITLE
Revert the change of `local` volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 
 ## Overview
 
-Local Path Provisioner provides a way for the Kubernetes users to utilize the local storage in each node. Based on the user configuration, the Local Path Provisioner will create `local` based persistent volume on the node automatically. It utilizes the features introduced by Kubernetes [Local Persistent Volume feature](https://kubernetes.io/blog/2018/04/13/local-persistent-volumes-beta/), but make it a simpler solution than the built-in `local` volume feature in Kubernetes.
+Local Path Provisioner provides a way for the Kubernetes users to utilize the local storage in each node. Based on the user configuration, the Local Path Provisioner will create `hostPath` based persistent volume on the node automatically. It utilizes the features introduced by Kubernetes [Local Persistent Volume feature](https://kubernetes.io/blog/2018/04/13/local-persistent-volumes-beta/), but make it a simpler solution than the built-in `local` volume feature in Kubernetes.
 
 ## Compare to built-in Local Persistent Volume feature in Kubernetes
 
 ### Pros
-Dynamic provisioning the volume using [local volume](https://kubernetes.io/docs/concepts/storage/volumes/#local).
+Dynamic provisioning the volume using hostPath.
 * Currently the Kubernetes [Local Volume provisioner](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner) cannot do dynamic provisioning for the local volumes.
 
 ### Cons
@@ -42,7 +42,7 @@ $ kubectl -n local-path-storage logs -f -l app=local-path-provisioner
 
 ## Usage
 
-Create a `local` backend Persistent Volume and a pod uses it:
+Create a `hostPath` backend Persistent Volume and a pod uses it:
 
 ```
 kubectl create -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/examples/pvc.yaml

--- a/provisioner.go
+++ b/provisioner.go
@@ -198,6 +198,7 @@ func (p *LocalPathProvisioner) Provision(opts pvController.ProvisionOptions) (*v
 	}
 
 	fs := v1.PersistentVolumeFilesystem
+	hostPathType := v1.HostPathDirectoryOrCreate
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -210,8 +211,9 @@ func (p *LocalPathProvisioner) Provision(opts pvController.ProvisionOptions) (*v
 				v1.ResourceName(v1.ResourceStorage): pvc.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)],
 			},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
-				Local: &v1.LocalVolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
 					Path: path,
+					Type: &hostPathType,
 				},
 			},
 			NodeAffinity: &v1.VolumeNodeAffinity{
@@ -261,11 +263,11 @@ func (p *LocalPathProvisioner) getPathAndNodeForPV(pv *v1.PersistentVolume) (pat
 		err = errors.Wrapf(err, "failed to delete volume %v", pv.Name)
 	}()
 
-	local := pv.Spec.PersistentVolumeSource.Local
-	if local == nil {
-		return "", "", fmt.Errorf("no Local set")
+	hostPath := pv.Spec.PersistentVolumeSource.HostPath
+	if hostPath == nil {
+		return "", "", fmt.Errorf("no HostPath set")
 	}
-	path = local.Path
+	path = hostPath.Path
 
 	nodeAffinity := pv.Spec.NodeAffinity
 	if nodeAffinity == nil {

--- a/scripts/ci
+++ b/scripts/ci
@@ -8,3 +8,8 @@ cd $(dirname $0)
 ./validate
 ./validate-ci
 ./package
+
+image=`cat ../bin/latest_image`
+
+echo
+echo Local Path Provisioner image: ${image}

--- a/scripts/package
+++ b/scripts/package
@@ -16,3 +16,5 @@ fi
 
 docker build -f ${DOCKERFILE} -t ${IMAGE} .
 echo Built ${IMAGE}
+
+echo ${IMAGE} > ./bin/latest_image


### PR DESCRIPTION
It breaks RKE.

Reopen: https://github.com/rancher/local-path-provisioner/issues/85
Revert: https://github.com/rancher/local-path-provisioner/pull/91