### PR TITLE
add default service account for debugging of out-of-cluster

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ var (
 	EnvHelperImage         = "HELPER_IMAGE"
 	DefaultHelperImage     = "busybox"
 	FlagServiceAccountName = "service-account-name"
+	DefaultServiceAccount  = "local-path-provisioner-service-account"
 	EnvServiceAccountName  = "SERVICE_ACCOUNT_NAME"
 	FlagKubeconfig         = "kubeconfig"
 	DefaultConfigFileKey   = "config.json"
@@ -98,6 +99,7 @@ func StartCmd() cli.Command {
 				Name:   FlagServiceAccountName,
 				Usage:  "Required. The ServiceAccountName for deployment",
 				EnvVar: EnvServiceAccountName,
+				Value:  DefaultServiceAccount,
 			},
 		},
 		Action: func(c *cli.Context) {


### PR DESCRIPTION
there is no need to use service account for debugging of out-of-cluster, while it could not start under current condition, so adding a default service account for debugging of out-of-cluster.