### PR TITLE
enable xfs quota and add an xfs quota script example 

### DIFF
--- a/examples/quota/Dockerfile
+++ b/examples/quota/Dockerfile
@@ -1,0 +1,3 @@
+From centos:7
+RUN yum install -y xfsprogs
+

--- a/examples/quota/README.md
+++ b/examples/quota/README.md
@@ -1,0 +1,7 @@
+# Overview
+this is an example to enable quota for xfs 
+
+# Usage
+> 1. build a helper image using the sample dockerfile to replace busybox helper image.
+> 2. use the sample setup and teardown script
+

--- a/examples/quota/setup
+++ b/examples/quota/setup
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+absolutePath=$1
+sizeInBytes=$2
+
+xfsPath=$(dirname "$absolutePath")
+pvcName=$(basename "$absolutePath")
+mkdir -p ${absolutePath}
+
+# support xfs quota
+type=`stat -f -c %T ${xfsPath}`
+if [ ${type} == 'xfs' ]; then
+
+    echo "support xfs quota"
+
+    project=`cat /etc/projects | tail -n 1`
+    id=`echo ${project%:*}`
+
+    if [ ! ${project} ]; then
+        id=1
+    else
+        id=$[${id}+1]
+    fi
+
+    echo "${id}:${absolutePath}" >> /etc/projects
+    echo "${pvcName}:${id}" >> /etc/projid
+
+    xfs_quota -x -c "project -s ${pvcName}"
+    xfs_quota -x -c "limit -p bhard=${sizeInBytes} ${pvcName}" ${xfsPath}
+    xfs_quota -x -c "report -pbih" ${xfsPath}
+fi

--- a/examples/quota/teardown
+++ b/examples/quota/teardown
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+absolutePath=$1
+xfsPath=$(dirname "$absolutePath")
+pvcName=$(basename "$absolutePath")
+
+# support xfs quota
+type=`stat -f -c %T ${xfsPath}`
+if [ ${type} == 'xfs' ]; then
+
+    echo "support xfs quota"
+    xfs_quota -x -c "limit -p bhard=0 ${pvcName}" ${xfsPath}
+fi
+
+rm -rf ${absolutePath}
+if [ ${type} == 'xfs' ]; then
+    echo "$(sed "/${pvcName}/d" /etc/projects)" >  /etc/projects
+    echo "$(sed "/${pvcName}/d" /etc/projid)" >  /etc/projid
+    xfs_quota -x -c "report -pbih" ${xfsPath}
+fi
+


### PR DESCRIPTION
it is unsecure since pod could write unlimited size for current local-path-provisoner, so i made some changes to enable xfs quota for clusters which has xfs. And this is also compatiable with non-xfs clusters.