### PR TITLE
use multi-stage Dockerfile for packaging

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,3 +1,9 @@
+FROM golang:1.15.2-alpine as builder
+
+COPY . /program
+WORKDIR /program
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o local-path-provisioner .
+
 FROM alpine
-COPY bin/local-path-provisioner /usr/bin/
-CMD ["local-path-provisioner"]
+COPY --from=builder /program/local-path-provisioner /usr/bin/
+CMD ["/usr/bin/local-path-provisioner"]


### PR DESCRIPTION
Use a multi-stage dockerfile to build the image and avoid using the binary built on the host directly.
