### PR TITLE
Do not create directory if not found

### DIFF
--- a/provisioner.go
+++ b/provisioner.go
@@ -202,7 +202,7 @@ func (p *LocalPathProvisioner) Provision(opts pvController.ProvisionOptions) (*v
 	}
 
 	fs := v1.PersistentVolumeFilesystem
-	hostPathType := v1.HostPathDirectoryOrCreate
+	hostPathType := v1.HostPathDirectory
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,


### PR DESCRIPTION
Use `type: Directory` instead of `type: DirectoryOrCreate` allows to block running workload on provisioned directories, to avoid the situations when initial storage is unmounted or broken.

docker image containing the fix:
```
kvaps/local-path-provisioner:v0.0.17-fix-137
```

fixes https://github.com/rancher/local-path-provisioner/issues/137