### PR TITLE
chore: removed duplicated fields from the configmap.yaml

### DIFF
--- a/deploy/chart/templates/configmap.yaml
+++ b/deploy/chart/templates/configmap.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
 {{ include "local-path-provisioner.labels" . | indent 4 }}
 data:
-apiVersion: v1
-data:
   config.json: |-
     {
       "nodePathMap": {{ .Values.nodePathMap | toPrettyJson | nindent 8 }}


### PR DESCRIPTION
Configmap.yaml file has 2 duplicated fields (probably created by copy paste?)

This MR removes them.