### PR TITLE
Revert "Do not create directory if not found"

### DIFF
--- a/provisioner.go
+++ b/provisioner.go
@@ -213,7 +213,7 @@ func (p *LocalPathProvisioner) Provision(opts pvController.ProvisionOptions) (*v
 	}
 
 	fs := v1.PersistentVolumeFilesystem
-	hostPathType := v1.HostPathDirectory
+	hostPathType := v1.HostPathDirectoryOrCreate
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,


### PR DESCRIPTION
Reverts rancher/local-path-provisioner#138

Due to it caused the following error in the RKE setup:

```
MountVolume.SetUp failed for volume "pvc-xxxx" : hostPath type check failed: /opt/local-path-provisioner/pvc-xxx is not a directory
```

And the directory indeed exists on the node.