### PR TITLE
Local Path Provisioner v0.0.18 release

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Use HostPath for persistent local storage with Kubernetes
 name: local-path-provisioner
-version: 0.0.17
-appVersion: "v0.0.17"
+version: 0.0.18
+appVersion: "v0.0.18"
 keywords:
   - storage
   - hostpath

--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -56,7 +56,7 @@ default values.
 | Parameter                           | Description                                                                     | Default                                                                             |
 | ----------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | `image.repository`                  | Local Path Provisioner image name                                               | `rancher/local-path-provisioner`                                                    |
-| `image.tag`                         | Local Path Provisioner image tag                                                | `v0.0.17`                                                                            |
+| `image.tag`                         | Local Path Provisioner image tag                                                | `v0.0.18`                                                                            |
 | `image.pullPolicy`                  | Image pull policy                                                               | `IfNotPresent`                                                                      |
 | `storageClass.create`               | If true, create a `StorageClass`                                                | `true`                                                                              |
 | `storageClass.provisionerName`      | The provisioner name for the storage class                                      | `nil`                                                                               |

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 
 image:
   repository: rancher/local-path-provisioner
-  tag: v0.0.17
+  tag: v0.0.18
   pullPolicy: IfNotPresent
 
 helperImage:

--- a/deploy/local-path-storage.yaml
+++ b/deploy/local-path-storage.yaml
@@ -58,7 +58,7 @@ spec:
       serviceAccountName: local-path-provisioner-service-account
       containers:
       - name: local-path-provisioner
-        image: rancher/local-path-provisioner:v0.0.17
+        image: rancher/local-path-provisioner:v0.0.18
         imagePullPolicy: IfNotPresent
         command:
         - local-path-provisioner

--- a/deploy/provisioner.yaml
+++ b/deploy/provisioner.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: local-path-provisioner-service-account
       containers:
       - name: local-path-provisioner
-        image: rancher/local-path-provisioner:v0.0.17
+        image: rancher/local-path-provisioner:v0.0.18
         imagePullPolicy: Always
         command:
         - local-path-provisioner


### PR DESCRIPTION
Changelog:
1. Thanks to @nickming 's PR, we've added the ability to make the helper
pod and setup/teardown script customizable. For example, now you can
setup the local path provisioner to use quota with btrfs.

2. Thanks to @hwaastad 's PR, now the helper pod supports pull secret.

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>