### PR TITLE
Fix error message related to the helper-pod-file flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -213,7 +213,7 @@ func startDaemon(c *cli.Context) error {
 	if helperPodFile == "" {
 		helperPodYaml, err = findConfigFileFromConfigMap(kubeClient, namespace, configMapName, DefaultHelperPodFile)
 		if err != nil {
-			return fmt.Errorf("invalid empty flag %v and it also does not exist at ConfigMap %v/%v with err: %v", FlagConfigFile, namespace, configMapName, err)
+			return fmt.Errorf("invalid empty flag %v and it also does not exist at ConfigMap %v/%v with err: %v", FlagHelperPodFile, namespace, configMapName, err)
 		}
 	} else {
 		helperPodYaml, err = loadFile(helperPodFile)


### PR DESCRIPTION
It's a very minor problem related to an error message introduced in #8740885, but I was confused.

When default configMap is used and `helperPod.yaml` is missing from the configMap, `main.go` complains about the `--config` flag instead of the `--helper-pod-file` flag.