### PR TITLE
use IfNotPresent image-pull-policy by default for helper-pod

### DIFF
--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -137,6 +137,7 @@ configmap:
       containers:
       - name: helper-pod
         image: busybox
+        imagePullPolicy: IfNotPresent
 
 
 

--- a/deploy/example-config.yaml
+++ b/deploy/example-config.yaml
@@ -66,5 +66,6 @@ data:
           containers:
           - name: helper-pod
             image: busybox
+            imagePullPolicy: IfNotPresent
 
 

--- a/deploy/local-path-storage.yaml
+++ b/deploy/local-path-storage.yaml
@@ -147,5 +147,6 @@ data:
           containers:
           - name: helper-pod
             image: busybox
+            imagePullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
I would like to suggest setting the _imagePullPolicy_ for the helper-pod to `IfNotPresent`.

Right now there is no image-tag given to the busybox-image, so `latest` is assumed - what implies _imagePullPolicy_ `Always` ([docs](https://kubernetes.io/docs/concepts/containers/images/#updating-images)). I've run quickly into the docker-hub-rate-limiting with that :)