### PR TITLE
Disable (un-needed) leader election to reduce pod restarts

### DIFF
--- a/main.go
+++ b/main.go
@@ -231,6 +231,7 @@ func startDaemon(c *cli.Context) error {
 		provisionerName,
 		provisioner,
 		serverVersion.GitVersion,
+		pvController.LeaderElection(false),
 	)
 	logrus.Debug("Provisioner started")
 	pc.Run(stopCh)


### PR DESCRIPTION
This is a very quick fix to disable leader election that is not needed for non-replicated storage classes. This stops pod restarts because of re-elections.