### PR TITLE
Support for shared filesystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,13 @@ data:
     1. If one node is listed but with `paths` set to `[]`, the provisioner will refuse to provision on this node.
     2. If more than one path was specified, the path would be chosen randomly when provisioning.
 
+`sharedFileSystemPath` allows the provisioner to use a filesystem that is mounted on all nodes at the same time.
+In this case all access modes are supported: `ReadWriteOnce`, `ReadOnlyMany` and `ReadWriteMany` for storage claims.
+
+In addition `volumeBindingMode: Immediate` can be used in  StorageClass definition.
+
+Please note that `nodePathMap` and `sharedFileSystemPath` are mutually exclusive. If `sharedFileSystemPath` is used, then `nodePathMap` must be set to `[]`.
+
 ##### Rules
 The configuration must obey following rules:
 1. `config.json` must be a valid json file.

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -58,6 +58,14 @@ nodePathMap:
     paths:
       - /opt/local-path-provisioner
 
+# `sharedFileSystemPath` allows the provisioner to use a filesystem that is mounted on all
+# nodes at the same time. In this case all access modes are supported: `ReadWriteOnce`,
+# `ReadOnlyMany` and `ReadWriteMany` for storage claims. In addition
+# `volumeBindingMode: Immediate` can be used in  StorageClass definition.
+# Please note that `nodePathMap` and `sharedFileSystemPath` are mutually exclusive.
+# If `sharedFileSystemPath` is used, then `nodePathMap` must be set to `[]`.
+# sharedFileSystemPath: ""
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/examples/shared-fs/deployment.yaml
+++ b/examples/shared-fs/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-path-rwx-example
+  labels:
+    app: local-path-rwx-example
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: local-path-rwx-example
+  template:
+    metadata:
+      labels:
+        app: local-path-rwx-example
+    spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app: local-path-rwx-example
+      containers:
+      - name: pause
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - 'hostname >> /data/shared.txt; sleep 3; cat /data/shared.txt; sleep infinity'
+        volumeMounts:
+        - name: volv
+          mountPath: /data
+        ports:
+        - containerPort: 80
+      volumes:
+      - name: volv
+        persistentVolumeClaim:
+          claimName: local-path-rwx-example

--- a/examples/shared-fs/pvc.yaml
+++ b/examples/shared-fs/pvc.yaml
@@ -1,0 +1,21 @@
+# Plesase note, configuration of the Local Path Provisioner should be set correspondingly
+# for this to work:
+#
+#  data:
+#    config.json: |-
+#      {
+#              "sharedFileSystemPath": "/shared/fs/mounted/on/the/same/path/on/all/nodes"
+#      }
+#
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: local-path-rwx-example
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: local-path
+  volumeMode: Filesystem


### PR DESCRIPTION
Instead of spamming in #174 I will create another PR.

This is an attempt to bring shared file systems support.

`sharedFileSystemPath` allows the provisioner to use a filesystem that is mounted on all nodes at the same time.
In this case all access modes are supported: `ReadWriteOnce`, `ReadOnlyMany` and `ReadWriteMany` for storage claims.

In addition `volumeBindingMode: Immediate` can be used in  StorageClass definition.

Please note that `nodePathMap` and `sharedFileSystemPath` are mutually exclusive. If `sharedFileSystemPath` is used, then `nodePathMap` must be set to `[]`.