### PR TITLE
[Feat] Add  the new feature to support the air-gapped situation

### DIFF
--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -137,6 +137,7 @@ configmap:
       containers:
       - name: helper-pod
         image: busybox
+        imagePullPolicy: IfNotPresent
 
 
 

--- a/deploy/example-config.yaml
+++ b/deploy/example-config.yaml
@@ -66,5 +66,6 @@ data:
       containers:
       - name: helper-pod
         image: busybox
+        imagePullPolicy: IfNotPresent
 
 

--- a/deploy/local-path-storage.yaml
+++ b/deploy/local-path-storage.yaml
@@ -153,5 +153,6 @@ data:
       containers:
       - name: helper-pod
         image: busybox
+        imagePullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
Signed-off-by: aisuko <urakiny@gmail.com>

Under the offline situation, we can only use the images that were pre-load to the host. The specification of `helperPod.yaml` used the default value `imagePullPolicy` which equals `Always` will let the help pod failed to work. So, we should declare the specification of the image pull policy as `IfNotPresent`.