### PR TITLE
indicate volume expansion is possible

### DIFF
--- a/debug/config.yaml
+++ b/debug/config.yaml
@@ -11,6 +11,7 @@ metadata:
 provisioner: rancher.io/local-path
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
+allowVolumeExpansion: true
 
 ---
 

--- a/deploy/chart/templates/storageclass.yaml
+++ b/deploy/chart/templates/storageclass.yaml
@@ -12,4 +12,5 @@ metadata:
 provisioner: {{ template "local-path-provisioner.provisionerName" . }}
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
+allowVolumeExpansion: true
 {{- end }}


### PR DESCRIPTION
By adding `allowVolumeExpansion` this will prevent errors if someone changes the PVC capacity size on an already provisioned PVC, since local-path-provisioner does not enforce disk usage anyways, it seems reasonable to allow the value to change without throwing an error.

However this will not update the status of the PVC, it'll still show the original amount. The project would need some sort of resource watch and update status to reflect status from spec.