### PR TITLE
Use busybox:1.33.1 in helper-pod

### DIFF
--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -136,10 +136,4 @@ configmap:
     spec:
       containers:
       - name: helper-pod
-        image: busybox
-        imagePullPolicy: IfNotPresent
-
-
-
-
-
+        image: busybox:1.33.1

--- a/deploy/example-config.yaml
+++ b/deploy/example-config.yaml
@@ -65,7 +65,4 @@ data:
     spec:
       containers:
       - name: helper-pod
-        image: busybox
-        imagePullPolicy: IfNotPresent
-
-
+        image: busybox:1.33.1

--- a/deploy/local-path-storage.yaml
+++ b/deploy/local-path-storage.yaml
@@ -152,7 +152,4 @@ data:
     spec:
       containers:
       - name: helper-pod
-        image: busybox
-        imagePullPolicy: IfNotPresent
-
-
+        image: busybox:1.33.1


### PR DESCRIPTION
Use busybox:1.33.1 - which is currently the latest available. The use of specific image tag also changes `imagePullPolicy` default from `Always` to `IfNotPresent` - which, among other things, behaves better in aigrap, see https://github.com/rancher/local-path-provisioner/pull/188#issuecomment-877459415.