### PR TITLE
Bump chart version aswell

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Use HostPath for persistent local storage with Kubernetes
 name: local-path-provisioner
-version: 0.0.19
+version: 0.0.20
 appVersion: "v0.0.20"
 keywords:
   - storage


### PR DESCRIPTION
Based on this file's history I guess helm chart version and local-path version must have the same value