### PR TITLE
Added options for worker threads and provisioning/deletion retry counts

### DIFF
--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -51,6 +51,14 @@ spec:
             - --worker-threads
             - {{ .Values.workerThreads }}
           {{- end }}
+          {{- if .Values.provisioningRetryCount }}
+            - --provisioning-retry-count
+            - {{ .Values.provisioningRetryCount }}
+          {{- end }}
+          {{- if .Values.deletionRetryCount }}
+            - --deletion-retry-count
+            - {{ .Values.deletionRetryCount }}
+          {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config/

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -47,6 +47,10 @@ spec:
           {{- end }}
             - --configmap-name
             - {{ .Values.configmap.name }}
+          {{- if .Values.workerThreads }}
+            - --worker-threads
+            - {{ .Values.workerThreads }}
+          {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config/

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -140,4 +140,10 @@ configmap:
         imagePullPolicy: IfNotPresent
 
 # Number of provisioner worker threads to call provision/delete simultaneously.
-workerThreads: 4
+# workerThreads: 4
+
+# Number of retries of failed volume provisioning. 0 means retry indefinitely.
+# provisioningRetryCount: 15
+
+# Number of retries of failed volume deletion. 0 means retry indefinitely.
+# deletionRetryCount: 15

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -139,7 +139,5 @@ configmap:
         image: busybox
         imagePullPolicy: IfNotPresent
 
-
-
-
-
+# Number of provisioner worker threads to call provision/delete simultaneously.
+workerThreads: 4

--- a/main.go
+++ b/main.go
@@ -19,28 +19,32 @@ import (
 )
 
 var (
-	VERSION                = "0.0.1"
-	FlagConfigFile         = "config"
-	FlagProvisionerName    = "provisioner-name"
-	EnvProvisionerName     = "PROVISIONER_NAME"
-	DefaultProvisionerName = "rancher.io/local-path"
-	FlagNamespace          = "namespace"
-	EnvNamespace           = "POD_NAMESPACE"
-	DefaultNamespace       = "local-path-storage"
-	FlagHelperImage        = "helper-image"
-	EnvHelperImage         = "HELPER_IMAGE"
-	DefaultHelperImage     = "rancher/library-busybox:1.32.1"
-	FlagServiceAccountName = "service-account-name"
-	DefaultServiceAccount  = "local-path-provisioner-service-account"
-	EnvServiceAccountName  = "SERVICE_ACCOUNT_NAME"
-	FlagKubeconfig         = "kubeconfig"
-	DefaultConfigFileKey   = "config.json"
-	DefaultConfigMapName   = "local-path-config"
-	FlagConfigMapName      = "configmap-name"
-	FlagHelperPodFile      = "helper-pod-file"
-	DefaultHelperPodFile   = "helperPod.yaml"
-	FlagWorkerThreads      = "worker-threads"
-	DefaultWorkerThreads   = 4
+	VERSION                       = "0.0.1"
+	FlagConfigFile                = "config"
+	FlagProvisionerName           = "provisioner-name"
+	EnvProvisionerName            = "PROVISIONER_NAME"
+	DefaultProvisionerName        = "rancher.io/local-path"
+	FlagNamespace                 = "namespace"
+	EnvNamespace                  = "POD_NAMESPACE"
+	DefaultNamespace              = "local-path-storage"
+	FlagHelperImage               = "helper-image"
+	EnvHelperImage                = "HELPER_IMAGE"
+	DefaultHelperImage            = "rancher/library-busybox:1.32.1"
+	FlagServiceAccountName        = "service-account-name"
+	DefaultServiceAccount         = "local-path-provisioner-service-account"
+	EnvServiceAccountName         = "SERVICE_ACCOUNT_NAME"
+	FlagKubeconfig                = "kubeconfig"
+	DefaultConfigFileKey          = "config.json"
+	DefaultConfigMapName          = "local-path-config"
+	FlagConfigMapName             = "configmap-name"
+	FlagHelperPodFile             = "helper-pod-file"
+	DefaultHelperPodFile          = "helperPod.yaml"
+	FlagWorkerThreads             = "worker-threads"
+	DefaultWorkerThreads          = pvController.DefaultThreadiness
+	FlagProvisioningRetryCount    = "provisioning-retry-count"
+	DefaultProvisioningRetryCount = pvController.DefaultFailedProvisionThreshold
+	FlagDeletionRetryCount        = "deletion-retry-count"
+	DefaultDeletionRetryCount     = pvController.DefaultFailedDeleteThreshold
 )
 
 func cmdNotFound(c *cli.Context, command string) {
@@ -113,6 +117,16 @@ func StartCmd() cli.Command {
 				Name:  FlagWorkerThreads,
 				Usage: "Number of provisioner worker threads.",
 				Value: DefaultWorkerThreads,
+			},
+			cli.IntFlag{
+				Name:  FlagProvisioningRetryCount,
+				Usage: "Number of retries of failed volume provisioning. 0 means retry indefinitely.",
+				Value: DefaultProvisioningRetryCount,
+			},
+			cli.IntFlag{
+				Name:  FlagDeletionRetryCount,
+				Usage: "Number of retries of failed volume deletion. 0 means retry indefinitely.",
+				Value: DefaultDeletionRetryCount,
 			},
 		},
 		Action: func(c *cli.Context) {
@@ -239,8 +253,8 @@ func startDaemon(c *cli.Context) error {
 		provisioner,
 		serverVersion.GitVersion,
 		pvController.LeaderElection(false),
-		pvController.FailedProvisionThreshold(0),
-		pvController.FailedDeleteThreshold(0),
+		pvController.FailedProvisionThreshold(c.Int(FlagProvisioningRetryCount)),
+		pvController.FailedDeleteThreshold(c.Int(FlagDeletionRetryCount)),
 		pvController.Threadiness(c.Int(FlagWorkerThreads)),
 	)
 	logrus.Debug("Provisioner started")

--- a/main.go
+++ b/main.go
@@ -39,6 +39,8 @@ var (
 	FlagConfigMapName      = "configmap-name"
 	FlagHelperPodFile      = "helper-pod-file"
 	DefaultHelperPodFile   = "helperPod.yaml"
+	FlagWorkerThreads      = "worker-threads"
+	DefaultWorkerThreads   = 4
 )
 
 func cmdNotFound(c *cli.Context, command string) {
@@ -106,6 +108,11 @@ func StartCmd() cli.Command {
 				Name:  FlagHelperPodFile,
 				Usage: "Paths to the Helper pod yaml file",
 				Value: "",
+			},
+			cli.IntFlag{
+				Name:  FlagWorkerThreads,
+				Usage: "Number of provisioner worker threads.",
+				Value: DefaultWorkerThreads,
 			},
 		},
 		Action: func(c *cli.Context) {
@@ -232,6 +239,7 @@ func startDaemon(c *cli.Context) error {
 		provisioner,
 		serverVersion.GitVersion,
 		pvController.LeaderElection(false),
+		pvController.Threadiness(c.Int(FlagWorkerThreads)),
 	)
 	logrus.Debug("Provisioner started")
 	pc.Run(stopCh)

--- a/main.go
+++ b/main.go
@@ -243,6 +243,21 @@ func startDaemon(c *cli.Context) error {
 		}
 	}
 
+	provisioningRetryCount := c.Int(FlagProvisioningRetryCount)
+	if provisioningRetryCount < 0 {
+		return fmt.Errorf("invalid negative integer flag %v", FlagProvisioningRetryCount)
+	}
+
+	deletionRetryCount := c.Int(FlagDeletionRetryCount)
+	if deletionRetryCount < 0 {
+		return fmt.Errorf("invalid negative integer flag %v", FlagDeletionRetryCount)
+	}
+
+	workerThreads := c.Int(FlagWorkerThreads)
+	if workerThreads <= 0 {
+		return fmt.Errorf("invalid zero or negative integer flag %v", FlagWorkerThreads)
+	}
+
 	provisioner, err := NewProvisioner(stopCh, kubeClient, configFile, namespace, helperImage, configMapName, serviceAccountName, helperPodYaml)
 	if err != nil {
 		return err
@@ -253,9 +268,9 @@ func startDaemon(c *cli.Context) error {
 		provisioner,
 		serverVersion.GitVersion,
 		pvController.LeaderElection(false),
-		pvController.FailedProvisionThreshold(c.Int(FlagProvisioningRetryCount)),
-		pvController.FailedDeleteThreshold(c.Int(FlagDeletionRetryCount)),
-		pvController.Threadiness(c.Int(FlagWorkerThreads)),
+		pvController.FailedProvisionThreshold(provisioningRetryCount),
+		pvController.FailedDeleteThreshold(deletionRetryCount),
+		pvController.Threadiness(workerThreads),
 	)
 	logrus.Debug("Provisioner started")
 	pc.Run(stopCh)

--- a/main.go
+++ b/main.go
@@ -239,6 +239,8 @@ func startDaemon(c *cli.Context) error {
 		provisioner,
 		serverVersion.GitVersion,
 		pvController.LeaderElection(false),
+		pvController.FailedProvisionThreshold(0),
+		pvController.FailedDeleteThreshold(0),
 		pvController.Threadiness(c.Int(FlagWorkerThreads)),
 	)
 	logrus.Debug("Provisioner started")


### PR DESCRIPTION
The 'sig-storage-lib-external-provisioner' provides an option for volume provisioning and deletion concurrency. so, I added an option like '--worker-threads' to allow users to control provisioning concurrency. Failed provision/delete threshold values are zero, so the provisioner can complete provisioning and deletion.
Please review.