### PR TITLE
Do not create directory if not found

### DIFF
--- a/provisioner.go
+++ b/provisioner.go
@@ -215,7 +215,7 @@ func (p *LocalPathProvisioner) Provision(opts pvController.ProvisionOptions) (*v
 	}
 
 	fs := v1.PersistentVolumeFilesystem
-	hostPathType := v1.HostPathDirectoryOrCreate
+	hostPathType := v1.HostPathDirectory
 
 	valueNode, ok := node.GetLabels()[KeyNode]
 	if !ok {


### PR DESCRIPTION
Same as https://github.com/rancher/local-path-provisioner/pull/138, second attempt

Use `type: Directory` instead of `type: DirectoryOrCreate` allows to block running workload on provisioned directories, to avoid the situations when initial storage is unmounted or broken.

fixes https://github.com/rancher/local-path-provisioner/issues/137