### PR TITLE
Fix depreciated kubectl instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ kubectl create -f https://raw.githubusercontent.com/rancher/local-path-provision
 
 Check the volume content:
 ```
-$ kubectl exec volume-test cat /data/test
+$ kubectl exec volume-test -- sh -c "cat /data/test"
 local-path-test
 ```
 


### PR DESCRIPTION
I was walking through the great demo in the readme and ran into a little nit. `kubectl exec` has deprecated support for an older command format. This updates to the newer format which is also used higher up in the document. Nothing is broken but this may prevent a larger error as `kubectl` updates.

Issue example:
```sh
kagold@nuc-device:~$ kubectl exec volume-test cat /data/test
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
local-path-test
```