### PR TITLE
drop unnecessary imagePullSecrets setting on charts for deplyment

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/deployment.yaml
+++ b/deploy/chart/local-path-provisioner/templates/deployment.yaml
@@ -16,10 +16,6 @@ spec:
         app.kubernetes.io/name: {{ include "local-path-provisioner.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-    {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
       serviceAccountName: {{ template "local-path-provisioner.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
Setting imagePullSecrets and serviceAccountName in the same time, is unnecessary, and may set the wrong secrets which will disable the sa.