### PR TITLE
fix: imagePullSecrets setting for serviceAccount

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/serviceaccount.yaml
+++ b/deploy/chart/local-path-provisioner/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "local-path-provisioner.serviceAccountName" . }}
   labels:
 {{ include "local-path-provisioner.labels" . | indent 4 }}
-{{- with .Values.imagePullSecrets }}
 imagePullSecrets:
+{{- with .Values.imagePullSecrets }}
   {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- if .Values.defaultSettings.registrySecret }}


### PR DESCRIPTION
setting registry and no .Values.imagePullSecrets helm template error
Signed-off-by: tgfree <tgfree7@gmail.com>