### PR TITLE
Add option to create local volumes instead of hostPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Local Path Provisioner provides a way for the Kubernetes users to utilize the lo
 ## Compare to built-in Local Persistent Volume feature in Kubernetes
 
 ### Pros
-Dynamic provisioning the volume using [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) or [local volume](https://kubernetes.io/docs/concepts/storage/volumes/#local).
+Dynamic provisioning the volume using [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) or [local](https://kubernetes.io/docs/concepts/storage/volumes/#local).
 * Currently the Kubernetes [Local Volume provisioner](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner) cannot do dynamic provisioning for the local volumes.
 
 ### Cons

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 
 ## Overview
 
-Local Path Provisioner provides a way for the Kubernetes users to utilize the local storage in each node. Based on the user configuration, the Local Path Provisioner will create `hostPath` based persistent volume on the node automatically. It utilizes the features introduced by Kubernetes [Local Persistent Volume feature](https://kubernetes.io/blog/2018/04/13/local-persistent-volumes-beta/), but makes it a simpler solution than the built-in `local` volume feature in Kubernetes.
+Local Path Provisioner provides a way for the Kubernetes users to utilize the local storage in each node. Based on the user configuration, the Local Path Provisioner will create either `hostPath` or `local` based persistent volume on the node automatically. It utilizes the features introduced by Kubernetes [Local Persistent Volume feature](https://kubernetes.io/blog/2018/04/13/local-persistent-volumes-beta/), but makes it a simpler solution than the built-in `local` volume feature in Kubernetes.
 
 ## Compare to built-in Local Persistent Volume feature in Kubernetes
 
 ### Pros
-Dynamic provisioning the volume using hostPath.
+Dynamic provisioning the volume using [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) or [local volume](https://kubernetes.io/docs/concepts/storage/volumes/#local).
 * Currently the Kubernetes [Local Volume provisioner](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner) cannot do dynamic provisioning for the local volumes.
 
 ### Cons

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Local Path Provisioner provides a way for the Kubernetes users to utilize the lo
 ### Pros
 Dynamic provisioning the volume using [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) or [local](https://kubernetes.io/docs/concepts/storage/volumes/#local).
 * Currently the Kubernetes [Local Volume provisioner](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner) cannot do dynamic provisioning for the local volumes.
+* Local based persistent volumes are an experimental feature ([example usage](examples/pvc-with-local-volume/pvc.yaml)).
 
 ### Cons
 1. No support for the volume capacity limit currently.

--- a/examples/pod-with-local-volume/kustomization.yaml
+++ b/examples/pod-with-local-volume/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../pvc-with-local-volume
+- pod.yaml

--- a/examples/pod-with-local-volume/pod.yaml
+++ b/examples/pod-with-local-volume/pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: volume-test
+spec:
+  containers:
+  - name: volume-test
+    image: nginx:stable-alpine
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+    - name: volv
+      mountPath: /data
+    ports:
+    - containerPort: 80
+  volumes:
+  - name: volv
+    persistentVolumeClaim:
+      claimName: local-volume-pvc

--- a/examples/pvc-with-local-volume/kustomization.yaml
+++ b/examples/pvc-with-local-volume/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- pvc.yaml

--- a/examples/pvc-with-local-volume/pvc.yaml
+++ b/examples/pvc-with-local-volume/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: local-volume-pvc
+  annotations:
+    volumeType: local
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 128Mi

--- a/test/pod_test.go
+++ b/test/pod_test.go
@@ -164,8 +164,10 @@ func runTest(p *PodTestSuite, images []string, waitCondition, volumeType string)
 
 	typeCheckCmd := fmt.Sprintf("kubectl get pv $(%s) -o jsonpath='{.spec.%s}'", "kubectl get pv -o jsonpath='{.items[0].metadata.name}'", volumeType)
 	c := createCmd(p.T(), typeCheckCmd, kustomizeDir, p.config.envs(), nil)
-	typeCheckOutput, _ := c.CombinedOutput()
-	fmt.Println(string(typeCheckOutput))
+	typeCheckOutput, err := c.CombinedOutput()
+	if err != nil {
+		p.FailNow("", "failed to check volume type: %v", err)
+	}
 	if len(typeCheckOutput) == 0 || !strings.Contains(string(typeCheckOutput), "path") {
 		p.FailNow("volume Type not correct")
 	}

--- a/test/testdata/pod-with-local-volume/kustomization.yaml
+++ b/test/testdata/pod-with-local-volume/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../../deploy
-- ../../../examples/pod-with-subpath
+- ../../../examples/pod-with-local-volume
 commonLabels:
   app: local-path-provisioner
 images:


### PR DESCRIPTION
resolve #85

Took the changes from #91 and added them to be enabled by ~~a config value~~ an annotation on the pvc. Default behavior is still to use hostPath volumes. By using an annotation, we can allow the user to create both `hostPath` and `local` volumes, instead of just locking down to one.

Made some small changes to the README, but will update the README and examples further if code changes are ok from maintainers.