### PR TITLE
fix quota example

### DIFF
--- a/examples/quota/debug.yaml
+++ b/examples/quota/debug.yaml
@@ -134,7 +134,17 @@ data:
         - name: xfs-quota-projects
           subPath: projid
           mountPath: /etc/projid
+        - name: device-dir
+          mountPath: /dev
       volumes:
       - name: xfs-quota-projects
         hostPath:
-          path: /etc
+          path: /etc/projects
+          type: FileOrCreate
+      - name: xfs-quota-projid
+        hostPath:
+          path: /etc/projid
+          type: FileOrCreate
+      - name: device-dir
+        hostPath:
+          path: /dev

--- a/examples/quota/helperPod.yaml
+++ b/examples/quota/helperPod.yaml
@@ -16,7 +16,17 @@ spec:
     - name: xfs-quota-projects
       subPath: projid
       mountPath: /etc/projid
+    - name: device-dir
+      mountPath: /dev
   volumes:
   - name: xfs-quota-projects
     hostPath:
-      path: /etc
+      path: /etc/projects
+      type: FileOrCreate
+  - name: xfs-quota-projid
+    hostPath:
+      path: /etc/projid
+      type: FileOrCreate
+  - name: device-dir
+    hostPath:
+      path: /dev

--- a/examples/quota/local-path-storage.yaml
+++ b/examples/quota/local-path-storage.yaml
@@ -268,7 +268,17 @@ data:
         - name: xfs-quota-projects
           subPath: projid
           mountPath: /etc/projid
+        - name: device-dir
+          mountPath: /dev
       volumes:
       - name: xfs-quota-projects
         hostPath:
-          path: /etc
+          path: /etc/projects
+          type: FileOrCreate
+      - name: xfs-quota-projid
+        hostPath:
+          path: /etc/projid
+          type: FileOrCreate
+      - name: device-dir
+        hostPath:
+          path: /dev


### PR DESCRIPTION
fix xfs quota example, the helper pod need mount /dev.
fix https://github.com/rancher/local-path-provisioner/issues/195