### PR TITLE
Multiple storage classes for same provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ A few things to note; the annotation for the `StorageClass` will apply to all vo
 
 ### Storage classes
 
-If more than one `paths` are specified in the `nodePathMap` the path is chosen randomly. To make the provisioner choose a specific path, use a `storageClass` defined with a parameter called `path`.
+If more than one `paths` are specified in the `nodePathMap` the path is chosen randomly. To make the provisioner choose a specific path, use a `storageClass` defined with a parameter called `nodePath`. Note that this path should be defined in the `nodePathMap`
 
 ```
 apiVersion: storage.k8s.io/v1
@@ -260,7 +260,7 @@ metadata:
   name: ssd-local-path
 provisioner: cluster.local/local-path-provisioner
 parameters:
-  path: /data/ssd
+  nodePath: /data/ssd
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ```

--- a/README.md
+++ b/README.md
@@ -249,6 +249,24 @@ annotations:
 
 A few things to note; the annotation for the `StorageClass` will apply to all volumes using it and is superseded by the annotation on the PVC if one is provided. If neither of the annotations was provided then we default to `hostPath`.
 
+### Storage classes
+
+If more than one `paths` are specified in the `nodePathMap` the path is chosen randomly. To make the provisioner choose a specific path, use a `storageClass` defined with a parameter called `path`.
+
+```
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ssd-local-path
+provisioner: cluster.local/local-path-provisioner
+parameters:
+  path: /data/ssd
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+```
+
+Here the provisioner will use the path `/data/ssd` when storage class `ssd-local-path` is used.
+
 ## Uninstall
 
 Before uninstallation, make sure the PVs created by the provisioner have already been deleted. Use `kubectl get pv` and make sure no PV with StorageClass `local-path`.

--- a/provisioner.go
+++ b/provisioner.go
@@ -230,6 +230,7 @@ func (p *LocalPathProvisioner) isSharedFilesystem() (bool, error) {
 func (p *LocalPathProvisioner) Provision(ctx context.Context, opts pvController.ProvisionOptions) (*v1.PersistentVolume, pvController.ProvisioningState, error) {
 	pvc := opts.PVC
 	node := opts.SelectedNode
+	storageClass := opts.StorageClass
 	sharedFS, err := p.isSharedFilesystem()
 	if err != nil {
 		return nil, pvController.ProvisioningFinished, err
@@ -253,7 +254,13 @@ func (p *LocalPathProvisioner) Provision(ctx context.Context, opts pvController.
 		// This clause works only with sharedFS
 		nodeName = node.Name
 	}
-	basePath, err := p.getRandomPathOnNode(nodeName)
+	var basePath string
+	basePath, err = p.getRandomPathOnNode(nodeName)
+	if storageClass.Parameters != nil {
+		if _, ok := storageClass.Parameters["path"]; ok {
+			basePath = storageClass.Parameters["path"]
+		}
+	}
 	if err != nil {
 		return nil, pvController.ProvisioningFinished, err
 	}


### PR DESCRIPTION
We have multiple disks mounted on a node and depending on the type of storage requirement we want to create the local path pvc on a particular disk. Today we can specify multiple paths on a node via the `nodePathMap:` but the final path selection is random.

I propose to create multiple storage classes with a parameter of `path` that specifies the path to use. That way, using a storage class like below I can provision the storage on the right folder.

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: ssd-local-path
  labels:
    app.kubernetes.io/name: local-path-provisioner
    helm.sh/chart: local-path-provisioner-0.0.23
    app.kubernetes.io/instance: local-path-provisioner
    app.kubernetes.io/version: "v0.0.23"
    app.kubernetes.io/managed-by: Helm
provisioner: cluster.local/local-path-provisioner
parameters:
  path: /data/ssd
volumeBindingMode: WaitForFirstConsumer
reclaimPolicy: Delete
```
If the path parameter is not found on the storage class, it falls back to existing behaviour.
