### PR TITLE
Set default volume type in storage class

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ If the reload fails, the provisioner will log the error and **continue using the
 
 >time="2018-10-03T06:39:28Z" level=error msg="failed to load the new config file: config canonicalization failed: duplicate node yasker-lp-dev3"
 
-#### Volume Types
+### Volume Types
 
 To specify the type of volume you want the provisioner to create, add either of the following annotations;
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,24 @@ If the reload fails, the provisioner will log the error and **continue using the
 
 >time="2018-10-03T06:39:28Z" level=error msg="failed to load the new config file: config canonicalization failed: duplicate node yasker-lp-dev3"
 
+#### Volume Types
+
+To specify the type of volume you want the provisioner to create, add either of the following annotations;
+
+- PVC: 
+```yaml
+annotations:
+  volumeType: <local or hostPath>
+```
+
+- StorageClass:
+```yaml
+annotations:
+  defaultVolumeType: <local or hostPath>
+```
+
+A few things to note; the annotation for the `StorageClass` will apply to all volumes using it and is superseded by the annotation on the PVC if one is provided. If neither of the annotations was provided then we default to `hostPath`.
+
 ## Uninstall
 
 Before uninstallation, make sure the PVs created by the provisioner have already been deleted. Use `kubectl get pv` and make sure no PV with StorageClass `local-path`.

--- a/provisioner.go
+++ b/provisioner.go
@@ -282,16 +282,17 @@ func (p *LocalPathProvisioner) Provision(ctx context.Context, opts pvController.
 	fs := v1.PersistentVolumeFilesystem
 
 	var pvs v1.PersistentVolumeSource
-	if pvcVal, ok := opts.PVC.GetAnnotations()["volumeType"]; ok {
-		// volume type specified in PVC
-		pvs = createPersistentVolumeSource(pvcVal, path)
-	} else if scVal, ok := opts.StorageClass.GetAnnotations()["defaultVolumeType"]; ok {
-		// default volume type provided for storage class
-		pvs = createPersistentVolumeSource(scVal, path)
-	} else {
-		// volume type unspecified, we default to hostPath
-		pvs = createPersistentVolumeSource("hostPath", path)
+	defaultVolumeType := "hostPath"
+	if dVal, ok := opts.StorageClass.GetAnnotations()["defaultVolumeType"]; ok {
+		defaultVolumeType = dVal
 	}
+	var volumeType string
+	if val, ok := opts.PVC.GetAnnotations()["volumeType"]; ok {
+		volumeType = val
+	} else {
+		volumeType = defaultVolumeType
+	}
+	pvs = createPersistentVolumeSource(volumeType, path)
 
 	var nodeAffinity *v1.VolumeNodeAffinity
 	if sharedFS {

--- a/provisioner.go
+++ b/provisioner.go
@@ -661,6 +661,14 @@ func createPersistentVolumeSource(volumeType string, path string) v1.PersistentV
 				Path: path,
 			},
 		}
+	case "hostpath":
+		hostPathType := v1.HostPathDirectoryOrCreate
+		pvs = v1.PersistentVolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: path,
+				Type: &hostPathType,
+			},
+		}
 	default:
 		hostPathType := v1.HostPathDirectoryOrCreate
 		pvs = v1.PersistentVolumeSource{

--- a/provisioner.go
+++ b/provisioner.go
@@ -45,6 +45,7 @@ const (
 
 const (
 	defaultCmdTimeoutSeconds = 120
+	defaultVolumeType        = "hostPath"
 )
 
 var (
@@ -282,15 +283,14 @@ func (p *LocalPathProvisioner) Provision(ctx context.Context, opts pvController.
 	fs := v1.PersistentVolumeFilesystem
 
 	var pvs v1.PersistentVolumeSource
-	defaultVolumeType := "hostPath"
-	if dVal, ok := opts.StorageClass.GetAnnotations()["defaultVolumeType"]; ok {
-		defaultVolumeType = dVal
-	}
 	var volumeType string
-	if val, ok := opts.PVC.GetAnnotations()["volumeType"]; ok {
-		volumeType = val
+	if dVal, ok := opts.StorageClass.GetAnnotations()["defaultVolumeType"]; ok {
+		volumeType = dVal
 	} else {
 		volumeType = defaultVolumeType
+	}
+	if val, ok := opts.PVC.GetAnnotations()["volumeType"]; ok {
+		volumeType = val
 	}
 	pvs, err = createPersistentVolumeSource(volumeType, path)
 	if err != nil {

--- a/test/pod_test.go
+++ b/test/pod_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package test
@@ -6,9 +7,9 @@ import (
 	"fmt"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/stretchr/testify/suite"
+	"strings"
 	"testing"
 	"time"
-	"strings"
 )
 
 const (
@@ -85,6 +86,12 @@ func (p *PodTestSuite) TestPodWithHostPathVolume() {
 
 func (p *PodTestSuite) TestPodWithLocalVolume() {
 	p.kustomizeDir = "pod-with-local-volume"
+
+	runTest(p, []string{p.config.IMAGE}, "ready", localVolumeType)
+}
+
+func (p *PodTestSuite) TestPodWithLocalVolumeDefault() {
+	p.kustomizeDir = "pod-with-default-local-volume"
 
 	runTest(p, []string{p.config.IMAGE}, "ready", localVolumeType)
 }

--- a/test/testdata/pod-with-default-local-volume/kustomization.yaml
+++ b/test/testdata/pod-with-default-local-volume/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../deploy
+- ../../../examples/pod
+patches:
+- path: patch.yaml
+commonLabels:
+  app: local-path-provisioner
+images:
+- name: rancher/local-path-provisioner
+  newTag: dev

--- a/test/testdata/pod-with-default-local-volume/patch.yaml
+++ b/test/testdata/pod-with-default-local-volume/patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path
+  annotations:
+    defaultVolumeType: local
+provisioner: rancher.io/local-path
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
We have  many `StatefulSet` workloads requiring the provisioner to create `local` volumes during provisioning. For several of these `StatefulSets`, we are unable to add the `volumeType` annotation which results in us having to use `hostPath` volumes which is unacceptable for us. Furthermore, it is tedious and error-prone to have to specify the `volumeType` annotation on every single PVC and would therefore prove useful to be able to specify a default volume type on the `StorageClass`.

I propose the addition of an annotation called `defaultVolumeType` on storage classes which will set the volume type for all volumes using that class. The annotation for the PVC can still be applied and will supersede the annotation on the storage class.

A basic example of a `StorageClass` with this annotation:

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: local-path
  annotations:
    defaultVolumeType: local
    storageclass.kubernetes.io/is-default-class: true
```