### PR TITLE
Helm: Add common labels value and update uninstall for helm 3

### DIFF
--- a/deploy/chart/local-path-provisioner/README.md
+++ b/deploy/chart/local-path-provisioner/README.md
@@ -43,7 +43,7 @@ The command deploys Local Path Provisioner on the Kubernetes cluster in the defa
 To uninstall/delete the `local-path-storage` deployment:
 
 ```console
-$ helm delete --purge local-path-storage
+$ helm uninstall local-path-storage
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -55,6 +55,7 @@ default values.
 
 | Parameter                           | Description                                                                     | Default                                                                             |
 | ----------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `commonLabels`                      | Custom labels to apply to all resources                                         | `{}`                                                                                |
 | `image.repository`                  | Local Path Provisioner image name                                               | `rancher/local-path-provisioner`                                                    |
 | `image.tag`                         | Local Path Provisioner image tag                                                | `master-head`                                                                       |
 | `image.pullPolicy`                  | Image pull policy                                                               | `IfNotPresent`                                                                      |

--- a/deploy/chart/local-path-provisioner/templates/_helpers.tpl
+++ b/deploy/chart/local-path-provisioner/templates/_helpers.tpl
@@ -42,6 +42,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/deploy/chart/local-path-provisioner/templates/deployment.yaml
+++ b/deploy/chart/local-path-provisioner/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "local-path-provisioner.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "local-path-provisioner.labels" . | indent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -1,6 +1,7 @@
 # Default values for local-path-provisioner.
 
 replicaCount: 1
+commonLabels: {}
 
 image:
   repository: rancher/local-path-provisioner


### PR DESCRIPTION
A value that is often in Helm charts is the `commonLabels` value, which seems to be absent from this chart. Common labels are also added to each of the pods in the deployment in this PR. 

Additionally, I changed the readme install instructions as `helm uninstall` no longer has the `--purge` flag and instead purges by default.