### PR TITLE
Helm: add pod tolerations to the helper-pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,11 +171,18 @@ data:
         metadata:
           name: helper-pod
         spec:
+          priorityClassName: system-node-critical
+          tolerations:
+            - key: node.kubernetes.io/disk-pressure
+              operator: Exists
+              effect: NoSchedule
           containers:
           - name: helper-pod
             image: busybox
 
 ```
+
+The helperPod is allowed to run on nodes experiencing disk pressure conditions, despite the potential resource constraints. When it runs on such a node, it can carry out specific cleanup tasks, freeing up space in PVCs, and resolving the disk-pressure issue.
 
 #### `config.json`
 
@@ -235,7 +242,7 @@ If the reload fails, the provisioner will log the error and **continue using the
 
 To specify the type of volume you want the provisioner to create, add either of the following annotations;
 
-- PVC: 
+- PVC:
 ```yaml
 annotations:
   volumeType: <local or hostPath>

--- a/deploy/chart/local-path-provisioner/templates/configmap.yaml
+++ b/deploy/chart/local-path-provisioner/templates/configmap.yaml
@@ -16,15 +16,20 @@ data:
     {{- end }}
     {{- $config | toPrettyJson | nindent 4 }}
   setup: |-
-    {{ .Values.configmap.setup | nindent 4 }}
+    {{- .Values.configmap.setup | nindent 4 }}
   teardown: |-
-    {{ .Values.configmap.teardown | nindent 4 }}
+    {{- .Values.configmap.teardown | nindent 4 }}
   helperPod.yaml: |-
     apiVersion: v1
     kind: Pod
     metadata:
       name: helper-pod
     spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: node.kubernetes.io/disk-pressure
+          operator: Exists
+          effect: NoSchedule
       containers:
         - name: helper-pod
           {{- if .Values.privateRegistry.registryUrl }}

--- a/deploy/example-config.yaml
+++ b/deploy/example-config.yaml
@@ -35,9 +35,12 @@ data:
     metadata:
       name: helper-pod
     spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: node.kubernetes.io/disk-pressure
+          operator: Exists
+          effect: NoSchedule
       containers:
       - name: helper-pod
         image: busybox
         imagePullPolicy: IfNotPresent
-
-

--- a/deploy/local-path-storage.yaml
+++ b/deploy/local-path-storage.yaml
@@ -122,9 +122,12 @@ data:
     metadata:
       name: helper-pod
     spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: node.kubernetes.io/disk-pressure
+          operator: Exists
+          effect: NoSchedule
       containers:
       - name: helper-pod
         image: busybox
         imagePullPolicy: IfNotPresent
-
-


### PR DESCRIPTION
I ran into a problem where the pod had filled up the PVC disk. 
As a result, the kubelet taint the node as `disk-pressure:NoSchedule`.
Once all the pods had moved out of the node, it was no longer possible to clean the disk using the local-path-provisioner.

The scheduler couldn't launch the helper-pod without pod tolerations.


Thank you.