### PR TITLE
Save the helper pod logs to the provisioner logs

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/clusterrole.yaml
+++ b/deploy/chart/local-path-provisioner/templates/clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "local-path-provisioner.labels" . | indent 4 }}
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods"]
+    resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods", "pods/log"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]

--- a/deploy/local-path-storage.yaml
+++ b/deploy/local-path-storage.yaml
@@ -28,7 +28,7 @@ metadata:
   name: local-path-provisioner-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods"]
+    resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods", "pods/log"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]

--- a/examples/quota/local-path-storage.yaml
+++ b/examples/quota/local-path-storage.yaml
@@ -28,7 +28,7 @@ metadata:
   name: local-path-provisioner-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods"]
+    resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods", "pods/log"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]

--- a/provisioner.go
+++ b/provisioner.go
@@ -709,13 +709,18 @@ func createPersistentVolumeSource(volumeType string, path string) (pvs v1.Persis
 	return pvs, nil
 }
 
+// saveHelperPodLogs takes what is in stdout/stderr from the helper
+// pod and logs it to the provisioner's logs. Returns an error if we
+// can't retrieve the helper pod logs.
 func saveHelperPodLogs(pod *v1.Pod) (err error) {
 	defer func() {
 		err = errors.Wrapf(err, "failed to save %s logs", pod.Name)
 	}()
 
 	// save helper pod logs
-	podLogOpts := v1.PodLogOptions{}
+	podLogOpts := v1.PodLogOptions{
+		Container: "helper-pod",
+	}
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		return fmt.Errorf("unable to retrieve in cluster config: %s", err.Error())
@@ -734,7 +739,7 @@ func saveHelperPodLogs(pod *v1.Pod) (err error) {
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, podLogs)
 	if err != nil {
-		return fmt.Errorf("error in copy information from podLogs to buf: %s", err.Error())
+		return fmt.Errorf("error in copying information from podLogs to buf: %s", err.Error())
 	}
 	podLogs.Close()
 


### PR DESCRIPTION
Given that the helper pods are so short lived, this gives us a very small window to view their logs before they're lost. I believe that saving these logs to the provisioner pod would greatly improve the observability of the system.

I've done this by implementing a function that gets called just before the helper pod is deleted which retrieves the logs and saves them to the provisioner. If an error is encountered when trying to retrieve the helper pod's logs, then the error message will be logged but the provisioning of the local storage will continue.

An example of what the provisioner's logs look like with this feature:

```
time="2023-04-12T10:04:50Z" level=info msg="Start of helper-pod-create-pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187 logs"
time="2023-04-12T10:04:50Z" level=info msg="hello world"
time="2023-04-12T10:04:50Z" level=info msg="Setting up volume"
time="2023-04-12T10:04:50Z" level=info msg="End of helper-pod-create-pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187 logs"
I0412 10:04:50.962618       1 controller.go:1442] provision "default/volv-workload-test-0" class "standard": volume "pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187" provisioned
I0412 10:04:50.962648       1 controller.go:1455] provision "default/volv-workload-test-0" class "standard": succeeded
I0412 10:04:50.962653       1 volume_store.go:212] Trying to save persistentvolume "pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187"
I0412 10:04:50.965309       1 volume_store.go:219] persistentvolume "pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187" saved
I0412 10:04:50.965541       1 event.go:282] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"default", Name:"volv-workload-test-0", UID:"6a843d61-8a2a-4b7f-99fe-ea308c41f187", APIVersion:"v1", ResourceVersion:"14006", FieldPath:""}): type: 'Normal' reason: 'ProvisioningSucceeded' Successfully provisioned volume pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187
I0412 10:05:52.734351       1 controller.go:1471] delete "pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187": started
time="2023-04-12T10:05:52Z" level=info msg="Deleting volume pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187 at local-worker2:/opt/local-path-provisioner/pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187_default_volv-workload-test-0"
time="2023-04-12T10:05:52Z" level=info msg="create the helper pod helper-pod-delete-pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187 into local-path-storage"
time="2023-04-12T10:05:55Z" level=info msg="Volume pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187 has been deleted on local-worker2:/opt/local-path-provisioner/pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187_default_volv-workload-test-0"
time="2023-04-12T10:05:55Z" level=info msg="Start of helper-pod-delete-pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187 logs"
time="2023-04-12T10:05:55Z" level=info msg=Teardown...
time="2023-04-12T10:05:55Z" level=info msg=Complete
time="2023-04-12T10:05:55Z" level=info msg="End of helper-pod-delete-pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187 logs"
I0412 10:05:55.760558       1 controller.go:1486] delete "pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187": volume deleted
I0412 10:05:55.762697       1 controller.go:1531] delete "pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187": persistentvolume deleted
I0412 10:05:55.762714       1 controller.go:1536] delete "pvc-6a843d61-8a2a-4b7f-99fe-ea308c41f187": succeeded
```