### PR TITLE
Helm: add namespace

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/configmap.yaml
+++ b/deploy/chart/local-path-provisioner/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.configmap.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "local-path-provisioner.labels" . | indent 4 }}
 data:

--- a/deploy/chart/local-path-provisioner/templates/deployment.yaml
+++ b/deploy/chart/local-path-provisioner/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "local-path-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "local-path-provisioner.labels" . | indent 4 }}
 spec:

--- a/deploy/chart/local-path-provisioner/templates/registry-secret.yaml
+++ b/deploy/chart/local-path-provisioner/templates/registry-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.defaultSettings.registrySecret }}
+  namespace: {{ .Release.Namespace }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "local-path-provisioner.secret" . }}

--- a/deploy/chart/local-path-provisioner/templates/serviceaccount.yaml
+++ b/deploy/chart/local-path-provisioner/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "local-path-provisioner.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "local-path-provisioner.labels" . | indent 4 }}
 imagePullSecrets:


### PR DESCRIPTION
Usually, helm uses in two cases: 
* helm update/install
* helm template

In first case, helm sets namespace during the deploy (everything fine here).
In second, the result of helm template can be used in `fluxcd` or `kubectl apply` pipeline.
But template does not have `namespace`, which can affect the result of deployment (deploy to default namespace)

Thank you.