### PR TITLE
Explicitly list the container registry by default

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/configmap.yaml
+++ b/deploy/chart/local-path-provisioner/templates/configmap.yaml
@@ -29,6 +29,6 @@ data:
           {{- if .Values.privateRegistry.registryUrl }}
           image: {{ .Values.privateRegistry.registryUrl }}/{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}
           {{- else }}
-          image: {{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}
+          image: {{ .Values.helperImage.defaultRegistry}}/{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/deploy/chart/local-path-provisioner/templates/deployment.yaml
+++ b/deploy/chart/local-path-provisioner/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         {{- if .Values.privateRegistry.registryUrl }}
           image: "{{ .Values.privateRegistry.registryUrl }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         {{- else }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.defaultRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
@@ -43,7 +43,7 @@ spec:
           {{- if .Values.privateRegistry.registryUrl }}
             - "{{ .Values.privateRegistry.registryUrl }}/{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}"
           {{- else }}
-            - "{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}"
+            - "{{ .Values.helperImage.defaultRegistry }}/{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}"
           {{- end }}
             - --configmap-name
             - {{ .Values.configmap.name }}

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -3,12 +3,14 @@
 replicaCount: 1
 
 image:
+  defaultRegistry: docker.io
   repository: rancher/local-path-provisioner
   tag: master-head
   pullPolicy: IfNotPresent
 
 helperImage:
-  repository: busybox
+  defaultRegistry: docker.io
+  repository: library/busybox
   tag: latest
 
 defaultSettings:


### PR DESCRIPTION
For my auditors, they want the registry listed for each container we are running.  Storing it here makes generating my reports much easier.