### PR TITLE
feat - Node name annotation

### DIFF
--- a/provisioner.go
+++ b/provisioner.go
@@ -342,14 +342,15 @@ func (p *LocalPathProvisioner) Provision(ctx context.Context, opts pvController.
 	}
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:        name,
+			Annotations: map[string]string{"local.path.provisioner/selected-node": nodeName},
 		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeReclaimPolicy: *opts.StorageClass.ReclaimPolicy,
 			AccessModes:                   pvc.Spec.AccessModes,
 			VolumeMode:                    &fs,
 			Capacity: v1.ResourceList{
-				v1.ResourceName(v1.ResourceStorage): pvc.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)],
+				v1.ResourceStorage: pvc.Spec.Resources.Requests[v1.ResourceStorage],
 			},
 			PersistentVolumeSource: pvs,
 			NodeAffinity:           nodeAffinity,

--- a/provisioner.go
+++ b/provisioner.go
@@ -48,6 +48,10 @@ const (
 	defaultVolumeType        = "hostPath"
 )
 
+const (
+	nodeNameAnnotationKey = "local.path.provisioner/selected-node"
+)
+
 var (
 	ConfigFileCheckInterval = 30 * time.Second
 
@@ -343,7 +347,7 @@ func (p *LocalPathProvisioner) Provision(ctx context.Context, opts pvController.
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Annotations: map[string]string{"local.path.provisioner/selected-node": nodeName},
+			Annotations: map[string]string{nodeNameAnnotationKey: nodeName},
 		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeReclaimPolicy: *opts.StorageClass.ReclaimPolicy,


### PR DESCRIPTION
# Motivation
When a node is terminating, it is necessary to handle any leftover objects associated with that node. To accomplish this, the node name is passed as a parameter upon receiving the termination event. Currently, the code searches for a node name match within the affinity, which can be cumbersome. To simplify the filtering and handling process, I propose adding an annotation with the selected node name. This will allow for easier independent filtering and handling of objects using a separate controller.

Description of the change:
* Added the selected node name to the annotations.
* Removed redundant conversion operations.