### PR TITLE
Add support for RISC-V

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -307,6 +307,78 @@ volumes:
 
 ---
 kind: pipeline
+name: riscv64
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build
+  image: rancher/dapper:v0.4.2
+  commands:
+  - ARCH=riscv64 SKIP_TEST=true SKIP_VALIDATE=true dapper ci
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+
+- name: github_binary_release
+  image: plugins/github-release
+  settings:
+    api_key:
+      from_secret: github_token
+    prerelease: true
+    checksum:
+    - sha256
+    checksum_file: CHECKSUMsum-riscv64.txt
+    checksum_flatten: true
+    files:
+    - "dist/artifacts/*"
+  when:
+    instance:
+    - drone-publish.rancher.io
+    event:
+    - tag
+
+- name: docker-publish
+  image: plugins/docker
+  settings:
+    dockerfile: package/Dockerfile
+    password:
+      from_secret: docker_password
+    repo: "rancher/local-path-provisioner"
+    tag: "${DRONE_BRANCH}-head-riscv64"
+    username:
+      from_secret: docker_username
+  when:
+    instance:
+    - drone-publish.rancher.io
+    event:
+    - push
+
+- name: docker-tagged-publish
+  image: plugins/docker
+  settings:
+    dockerfile: package/Dockerfile
+    password:
+      from_secret: docker_password
+    repo: "rancher/local-path-provisioner"
+    tag: "${DRONE_TAG}-riscv64"
+    username:
+      from_secret: docker_username
+  when:
+    instance:
+    - drone-publish.rancher.io
+    event:
+    - tag
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock
+
+---
+kind: pipeline
 name: manifest
 
 platform:
@@ -326,6 +398,7 @@ steps:
       - linux/arm64
       - linux/arm
       - linux/s390x
+      - linux/riscv64
     target: "rancher/local-path-provisioner:${DRONE_BRANCH}-head"
     template: "rancher/local-path-provisioner:${DRONE_BRANCH}-head-ARCH"
   when:
@@ -346,6 +419,7 @@ steps:
       - linux/arm64
       - linux/arm
       - linux/s390x
+      - linux/riscv64
     target: "rancher/local-path-provisioner:${DRONE_TAG}"
     template: "rancher/local-path-provisioner:${DRONE_TAG}-ARCH"
   when:
@@ -359,3 +433,4 @@ depends_on:
 - arm64
 - arm
 - s390x
+- riscv64

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,20 +1,20 @@
 FROM golang:1.17-alpine
 
 ARG DAPPER_HOST_ARCH
-ENV ARCH $DAPPER_HOST_ARCH
+ENV HOST_ARCH $DAPPER_HOST_ARCH
 
 RUN apk -U add bash git gcc musl-dev docker vim less file curl wget ca-certificates jq
 RUN rm -rf /go/src /go/pkg
-RUN if [ "${ARCH}" == "amd64" ]; then \
+RUN if [ "${HOST_ARCH}" == "amd64" ]; then \
         curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.41.1; \
     fi; \
-    if [ "${ARCH}" == "amd64" ] || [ "${ARCH}" == "arm64" ]; then \
-        kind_version=$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r ".tag_name") && curl -sL "https://kind.sigs.k8s.io/dl/${kind_version}/kind-linux-${ARCH}" -o kind && install kind /usr/local/bin; \
-        kubectl_version=$(curl -sL https://dl.k8s.io/release/stable.txt) && curl -sLO "https://dl.k8s.io/release/${kubectl_version}/bin/linux/${ARCH}/kubectl" && install kubectl /usr/local/bin; \
-        curl -sL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.2.0/kustomize_v4.2.0_linux_${ARCH}.tar.gz" | tar -zxv -C /usr/local/bin; \
+    if [ "${HOST_ARCH}" == "amd64" ] || [ "${HOST_ARCH}" == "arm64" ]; then \
+        kind_version=$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r ".tag_name") && curl -sL "https://kind.sigs.k8s.io/dl/${kind_version}/kind-linux-${HOST_ARCH}" -o kind && install kind /usr/local/bin; \
+        kubectl_version=$(curl -sL https://dl.k8s.io/release/stable.txt) && curl -sLO "https://dl.k8s.io/release/${kubectl_version}/bin/linux/${HOST_ARCH}/kubectl" && install kubectl /usr/local/bin; \
+        curl -sL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.2.0/kustomize_v4.2.0_linux_${HOST_ARCH}.tar.gz" | tar -zxv -C /usr/local/bin; \
     fi
 
-ENV DAPPER_ENV REPO TAG DRONE_TAG
+ENV DAPPER_ENV REPO TAG DRONE_TAG ARCH SKIP_TEST SKIP_VALIDATE
 ENV DAPPER_SOURCE /go/src/github.com/rancher/local-path-provisioner/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine
+ARG BASE=alpine
+FROM ${BASE}
 
 RUN apk update
 RUN apk upgrade --no-cache busybox zlib

--- a/scripts/build
+++ b/scripts/build
@@ -6,7 +6,11 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p bin
-if [ "$(uname)" = "Linux" ]; then
+if [ ${ARCH} = riscv64 ]; then
+    export GOOS="linux"
+    export GOARCH="riscv64"
+fi
+if [ "$(uname)" = "Linux" ] || [ "$ARCH" = "riscv64" ]; then
     OTHER_LINKFLAGS="-extldflags -static -s -w"
 fi
 LINKFLAGS="-X main.VERSION=$VERSION"

--- a/scripts/package
+++ b/scripts/package
@@ -14,7 +14,11 @@ if [ -e ${DOCKERFILE}.${ARCH} ]; then
     DOCKERFILE=${DOCKERFILE}.${ARCH}
 fi
 
-docker build -f ${DOCKERFILE} -t ${IMAGE} .
+if [ "$ARCH" = "riscv64" ]; then
+    export DOCKER_BUILDKIT=1
+    DOCKER_ARGS="--platform=$ARCH --build-arg=BASE=riscv64/alpine:edge"
+fi
+docker build ${DOCKER_ARGS} -f ${DOCKERFILE} -t ${IMAGE} .
 echo Built ${IMAGE}
 
 echo ${IMAGE} > ./bin/latest_image

--- a/scripts/test
+++ b/scripts/test
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+if [ -n "$SKIP_TEST" ]; then
+    echo Skipping testing
+    exit
+fi
+
 cd $(dirname $0)/..
 
 echo Running tests

--- a/scripts/validate
+++ b/scripts/validate
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+if [ -n "$SKIP_VALIDATE" ]; then
+    echo Skipping validation
+    exit
+fi
+
 cd $(dirname $0)/..
 
 echo Running validation


### PR DESCRIPTION
Adds the RISC-V architecture to the scripts involved in building and packaging Local Path Provisioner; no code changes.

The resulting container has been tested in QEMU with a [RISC-V build of K3s](https://github.com/k3s-io/k3s/pull/7778) and is working fine.

#### Notes

- A `riscv64` binary is generated by cross-compilation when `$ARCH == riscv64`.
- Testing and validation steps that are part of the `ci` script are skipped (options set via `SKIP_TEST` and `SKIP_VALIDATE` environment variables).
- The container image is built using Docker BuildKit. The base container image for Local Path Provisioner is now an argument, so it can be easily changed.
