### PR TITLE
Set default volume type of storage class from Helm chart

### DIFF
--- a/deploy/chart/local-path-provisioner/README.md
+++ b/deploy/chart/local-path-provisioner/README.md
@@ -61,7 +61,7 @@ default values.
 | `storageClass.create`               | If true, create a `StorageClass`                                                | `true`                                                                              |
 | `storageClass.provisionerName`      | The provisioner name for the storage class                                      | `nil`                                                                               |
 | `storageClass.defaultClass`         | If true, set the created `StorageClass` as the cluster's default `StorageClass` | `false`                                                                             |
-| `storageClass.defaultVolumeType`    | The default volume type this storage class creates                              | `local`                                                                             |
+| `storageClass.defaultVolumeType`    | The default volume type this storage class creates                              | `hostPath`                                                                          |
 | `storageClass.name`                 | The name to assign the created StorageClass                                     | local-path                                                                          |
 | `storageClass.reclaimPolicy`        | ReclaimPolicy field of the class                                                | Delete                                                                              |
 | `nodePathMap`                       | Configuration of where to store the data on each node                           | `[{node: DEFAULT_PATH_FOR_NON_LISTED_NODES, paths: [/opt/local-path-provisioner]}]` |

--- a/deploy/chart/local-path-provisioner/README.md
+++ b/deploy/chart/local-path-provisioner/README.md
@@ -61,6 +61,7 @@ default values.
 | `storageClass.create`               | If true, create a `StorageClass`                                                | `true`                                                                              |
 | `storageClass.provisionerName`      | The provisioner name for the storage class                                      | `nil`                                                                               |
 | `storageClass.defaultClass`         | If true, set the created `StorageClass` as the cluster's default `StorageClass` | `false`                                                                             |
+| `storageClass.defaultVolumeType`    | The default volume type this storage class creates                              | `local`                                                                             |
 | `storageClass.name`                 | The name to assign the created StorageClass                                     | local-path                                                                          |
 | `storageClass.reclaimPolicy`        | ReclaimPolicy field of the class                                                | Delete                                                                              |
 | `nodePathMap`                       | Configuration of where to store the data on each node                           | `[{node: DEFAULT_PATH_FOR_NON_LISTED_NODES, paths: [/opt/local-path-provisioner]}]` |

--- a/deploy/chart/local-path-provisioner/templates/storageclass.yaml
+++ b/deploy/chart/local-path-provisioner/templates/storageclass.yaml
@@ -5,9 +5,9 @@ metadata:
   name: {{ .Values.storageClass.name }}
   labels:
 {{ include "local-path-provisioner.labels" . | indent 4 }}
-annotations:
-  storageclass.kubernetes.io/is-default-class: "{{ .Values.storageClass.defaultClass }}"
-  defaultVolumeType: "{{ .Values.storageClass.defaultVolumeType }}"
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "{{ .Values.storageClass.defaultClass }}"
+    defaultVolumeType: "{{ .Values.storageClass.defaultVolumeType }}"
 provisioner: {{ template "local-path-provisioner.provisionerName" . }}
 volumeBindingMode: {{ .Values.storageClass.volumeBindingMode }}
 reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}

--- a/deploy/chart/local-path-provisioner/templates/storageclass.yaml
+++ b/deploy/chart/local-path-provisioner/templates/storageclass.yaml
@@ -5,10 +5,9 @@ metadata:
   name: {{ .Values.storageClass.name }}
   labels:
 {{ include "local-path-provisioner.labels" . | indent 4 }}
-{{- if .Values.storageClass.defaultClass }}
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
-{{- end }}
+annotations:
+  storageclass.kubernetes.io/is-default-class: "{{ .Values.storageClass.defaultClass }}"
+  defaultVolumeType: "{{ .Values.storageClass.defaultVolumeType }}"
 provisioner: {{ template "local-path-provisioner.provisionerName" . }}
 volumeBindingMode: {{ .Values.storageClass.volumeBindingMode }}
 reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -35,7 +35,7 @@ storageClass:
   defaultClass: false
 
   ## The default volume type this storage class creates, can be "local" or "hostPath"
-  defaultVolumeType: local
+  defaultVolumeType: hostPath
 
   ## Set a StorageClass name
   ## Ignored if storageClass.create is false

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -34,6 +34,9 @@ storageClass:
   ## Ignored if storageClass.create is false
   defaultClass: false
 
+  ## The default volume type this storage class creates, can be "local" or "hostPath"
+  defaultVolumeType: local
+
   ## Set a StorageClass name
   ## Ignored if storageClass.create is false
   name: local-path


### PR DESCRIPTION
This PR allows the user to set the default volume type of the storage class created by the Helm chart to either `local` or `hostPath` (default)
