### PR TITLE
deployment: Adapt values to be quoted when installed in templates

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/deployment.yaml
+++ b/deploy/chart/local-path-provisioner/templates/deployment.yaml
@@ -58,15 +58,15 @@ spec:
             - {{ .Values.configmap.name }}
           {{- if .Values.workerThreads }}
             - --worker-threads
-            - {{ .Values.workerThreads }}
+            - {{ .Values.workerThreads | quote }}
           {{- end }}
           {{- if .Values.provisioningRetryCount }}
             - --provisioning-retry-count
-            - {{ .Values.provisioningRetryCount }}
+            - {{ .Values.provisioningRetryCount | quote }}
           {{- end }}
           {{- if .Values.deletionRetryCount }}
             - --deletion-retry-count
-            - {{ .Values.deletionRetryCount }}
+            - {{ .Values.deletionRetryCount | quote }}
           {{- end }}
           volumeMounts:
             - name: config-volume


### PR DESCRIPTION
(initial title: deployment: Adapt 'workerThreads' to be a string)

There is a check in the main.go module [1] which expects it to be a string so it can convert it into an integer. Without this, we cannot actually provide the configuration without hitting a conversion error. This should fix it.

Currently, we are working around it by provided a double quoted string "'8'".

[1]  https://github.com/rancher/local-path-provisioner/blob/4d42c70e748fed13cd66f86656e909184a5b08d2/main.go#L254-L257
