### PR TITLE
Feature/multiple storage classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,11 @@ The helperPod is allowed to run on nodes experiencing disk pressure conditions, 
 `sharedFileSystemPath` allows the provisioner to use a filesystem that is mounted on all nodes at the same time.
 In this case all access modes are supported: `ReadWriteOnce`, `ReadOnlyMany` and `ReadWriteMany` for storage claims.
 
+`storageClassConfigs` is a map from storage class names to objects containing `nodePathMap` or `sharedFilesystemPath`, as described above.
+
 In addition `volumeBindingMode: Immediate` can be used in  StorageClass definition.
 
-Please note that `nodePathMap` and `sharedFileSystemPath` are mutually exclusive. If `sharedFileSystemPath` is used, then `nodePathMap` must be set to `[]`.
+Please note that `nodePathMap`, `sharedFileSystemPath`, and `storageClassConfigs` are mutually exclusive. If `sharedFileSystemPath` or `stroageClassConfigs` are used, then `nodePathMap` must be set to `[]`.
 
 The `setupCommand` and `teardownCommand` allow you to specify the path to binary files in helperPod that will be called when creating or deleting pvc respectively. This can be useful if you need to use distroless images for security reasons. See the examples/distroless directory for an example. A binary file can take the following parameters:
 | Parameter | Description |

--- a/deploy/chart/local-path-provisioner/templates/configmap.yaml
+++ b/deploy/chart/local-path-provisioner/templates/configmap.yaml
@@ -14,6 +14,9 @@ data:
     {{- with .Values.sharedFileSystemPath }}
     {{- $config = set $config "sharedFileSystemPath" . }}
     {{- end }}
+    {{- with .Values.multipleStorageClasses }}
+    {{- $config = set $config "sharedFileSystemPath" . }}
+    {{- end }}
     {{- $config | toPrettyJson | nindent 4 }}
   setup: |-
     {{- .Values.configmap.setup | nindent 4 }}

--- a/deploy/chart/local-path-provisioner/templates/configmap.yaml
+++ b/deploy/chart/local-path-provisioner/templates/configmap.yaml
@@ -14,8 +14,19 @@ data:
     {{- with .Values.sharedFileSystemPath }}
     {{- $config = set $config "sharedFileSystemPath" . }}
     {{- end }}
-    {{- with .Values.multipleStorageClasses }}
-    {{- $config = set $config "sharedFileSystemPath" . }}
+    {{- with .Values.storageClassConfigs }}
+    {{- $configs := dict }}
+    {{- range $key, $value := . }}
+      {{- $configValue := dict }}
+      {{- with $value.nodePathMap }}
+      {{- $configValue = set $configValue "nodePathMap" . }}
+      {{- end }}
+      {{- with $value.sharedFileSystemPath }}
+      {{- $configValue = set $configValue "sharedFileSystemPath" . }}
+      {{- end }}
+      {{- $configs = set $configs $key $configValue }}
+    {{- end }}
+    {{- $config = set $config "storageClassConfigs" $configs }}
     {{- end }}
     {{- $config | toPrettyJson | nindent 4 }}
   setup: |-

--- a/deploy/chart/local-path-provisioner/templates/storageclass.yaml
+++ b/deploy/chart/local-path-provisioner/templates/storageclass.yaml
@@ -1,15 +1,25 @@
-{{ if .Values.storageClass.create -}}
+{{- $storageClasses := list }}
+{{ if .Values.multipleStorageClasses }}
+{{ $storageClasses = .Values.multipleStorageClasses }}
+{{- else }}
+{{ $storageClasses = list .Values }}
+{{ end }}
+{{- $dot := . }}
+{{- range $values := $storageClasses }}
+{{ if $values.storageClass.create -}}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ .Values.storageClass.name }}
+  name: {{ $values.storageClass.name }}
   labels:
-{{ include "local-path-provisioner.labels" . | indent 4 }}
+{{ include "local-path-provisioner.labels" $dot | indent 4 }}
   annotations:
-    storageclass.kubernetes.io/is-default-class: "{{ .Values.storageClass.defaultClass }}"
-    defaultVolumeType: "{{ .Values.storageClass.defaultVolumeType }}"
-provisioner: {{ template "local-path-provisioner.provisionerName" . }}
-volumeBindingMode: {{ .Values.storageClass.volumeBindingMode }}
-reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
+    storageclass.kubernetes.io/is-default-class: "{{ $values.storageClass.defaultClass }}"
+    defaultVolumeType: "{{ $values.storageClass.defaultVolumeType }}"
+provisioner: {{ template "local-path-provisioner.provisionerName" $dot }}
+volumeBindingMode: {{ $values.storageClass.volumeBindingMode }}
+reclaimPolicy: {{ $values.storageClass.reclaimPolicy }}
 allowVolumeExpansion: true
+{{- end }}
+---
 {{- end }}

--- a/deploy/chart/local-path-provisioner/templates/storageclass.yaml
+++ b/deploy/chart/local-path-provisioner/templates/storageclass.yaml
@@ -1,16 +1,16 @@
 {{- $storageClasses := list }}
-{{ if .Values.multipleStorageClasses }}
-{{ $storageClasses = .Values.multipleStorageClasses }}
+{{ if .Values.storageClassConfigs }}
+{{ $storageClasses = .Values.storageClassConfigs }}
 {{- else }}
-{{ $storageClasses = list .Values }}
+{{ $storageClasses = dict .Values.storageClass.name .Values }}
 {{ end }}
 {{- $dot := . }}
-{{- range $values := $storageClasses }}
+{{- range $name, $values := $storageClasses }}
 {{ if $values.storageClass.create -}}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ $values.storageClass.name }}
+  name: {{ $name }}
   labels:
 {{ include "local-path-provisioner.labels" $dot | indent 4 }}
   annotations:

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -72,20 +72,21 @@ nodePathMap:
 # If `sharedFileSystemPath` is used, then `nodePathMap` must be set to `[]`.
 # sharedFileSystemPath: ""
 
-# `multipleStorageClasses` allows the provisioner to manage multiple independent storage classes.
+# `storageClassConfigs` allows the provisioner to manage multiple independent storage classes.
 # Each storage class must have a unique name, and contains the same fields as shown above for
 # a single storage class setup, EXCEPT for the provisionerName, which is the same for all
-# storage classes
-# multipleStorageClasses:
-# - storageClass:
-#     name: my-storage-class-name
-#     create: true
-#     defaultClass: false
-#     reclaimPolicy: Delete
-#   sharedFileSystemPath: ""
-#   ## OR
-#   # See above
-#   nodePathMap: {}
+# storage classes, and name, which is the key of the map.
+# storageClassConfigs: {}
+#   my-storage-class:
+#     storageClass:
+#       create: true
+#       defaultClass: false
+#       defaultVolumeType: hostPath
+#       reclaimPolicy: Delete
+#     sharedFileSystemPath: ""
+#     ## OR
+#     # See above
+#     nodePathMap: {}
     
 podAnnotations: {}
 

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -72,6 +72,21 @@ nodePathMap:
 # If `sharedFileSystemPath` is used, then `nodePathMap` must be set to `[]`.
 # sharedFileSystemPath: ""
 
+# `multipleStorageClasses` allows the provisioner to manage multiple independent storage classes.
+# Each storage class must have a unique name, and contains the same fields as shown above for
+# a single storage class setup, EXCEPT for the provisionerName, which is the same for all
+# storage classes
+# multipleStorageClasses:
+# - storageClass:
+#     name: my-storage-class-name
+#     create: true
+#     defaultClass: false
+#     reclaimPolicy: Delete
+#   sharedFileSystemPath: ""
+#   ## OR
+#   # See above
+#   nodePathMap: {}
+    
 podAnnotations: {}
 
 podSecurityContext: {}

--- a/test/pod_test.go
+++ b/test/pod_test.go
@@ -144,6 +144,12 @@ func (p *PodTestSuite) TestPodWithSubpath() {
 	runTest(p, []string{p.config.IMAGE}, "ready", hostPathVolumeType)
 }
 
+func (p *PodTestSuite) TestPodWithMultipleStorageClasses() {
+	p.kustomizeDir = "multiple-storage-classes"
+
+	runTest(p, []string{p.config.IMAGE}, "ready", hostPathVolumeType)
+}
+
 func runTest(p *PodTestSuite, images []string, waitCondition, volumeType string) {
 	kustomizeDir := testdataFile(p.kustomizeDir)
 

--- a/test/testdata/multiple-storage-classes/kustomization.yaml
+++ b/test/testdata/multiple-storage-classes/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../deploy
+- storage-class-shared.yaml
+- pod.yaml
+- pvc.yaml
+patchesStrategicMerge:
+- local-path-config.yaml
+commonLabels:
+  app: local-path-provisioner
+images:
+- name: rancher/local-path-provisioner
+  newTag: dev

--- a/test/testdata/multiple-storage-classes/local-path-config.yaml
+++ b/test/testdata/multiple-storage-classes/local-path-config.yaml
@@ -1,0 +1,23 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+data:
+  config.json: |-
+    {
+            "storageClassConfigs":{
+                   "local-path": {
+                          "nodePathMap": [
+                          {
+                                  "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+                                  "paths":["/opt/local-path-provisioner"]
+                          }
+                          ]
+                   },
+                   "local-path-shared": {
+                          "sharedFilesystemPath": "/opt/local-path-provisioner-shared"
+                   }
+            }
+    }
+

--- a/test/testdata/multiple-storage-classes/pod.yaml
+++ b/test/testdata/multiple-storage-classes/pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: volume-test
+spec:
+  containers:
+  - name: volume-test
+    image: nginx:stable-alpine
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+    - name: volv
+      mountPath: /data
+    - name: volv-shared
+      mountPath: /shared-data
+    ports:
+    - containerPort: 80
+  volumes:
+  - name: volv
+    persistentVolumeClaim:
+      claimName: local-path-pvc
+  - name: volv-shared
+    persistentVolumeClaim:
+      claimName: local-path-shared-pvc

--- a/test/testdata/multiple-storage-classes/pvc.yaml
+++ b/test/testdata/multiple-storage-classes/pvc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: local-path-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 128Mi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: local-path-shared-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: local-path-shared
+  resources:
+    requests:
+      storage: 128Mi

--- a/test/testdata/multiple-storage-classes/storage-class-shared.yaml
+++ b/test/testdata/multiple-storage-classes/storage-class-shared.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path-shared
+provisioner: rancher.io/local-path
+volumeBindingMode: Immediate
+reclaimPolicy: Delete
+


### PR DESCRIPTION
* Fixes https://github.com/rancher/local-path-provisioner/issues/38
* Fixes https://github.com/rancher/local-path-provisioner/issues/348

While is is currently possible to deploy multiple instances of the provisioner to support multiple storage classes, as well as to support both RWO, RWX, and ROX volumes at the same time, the additional resource consumption and deployment complexity are undesirable.

This patch adds an additional field to the `config.json` named `storageClassConfigs`, which is mutually exclusive with the existing `nodePathMap` and `sharedFilesystemPath` fields. This field is an object, whose keys are the names of storage classes, and its values are nested objects that contain either `nodePathMap` or `sharedFilesystemPath`. When a volume request is received, if this field is set, it is consulted for the configuration to use based on the name of the storage class, otherwise the original configuration fields are used.

This patch also updates the helm chart to add a matching option, which also deploys multiple storage class objects if selected.

This change is backwards compatible, installing this version of the provisioner should not break any existing installs.

One advantage of this change is that single-node k3s/k3d/kind clusters will be able to provide RWX and ROX storage classes out of the box.