### PR TITLE
Allow customizing helper pod

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/configmap.yaml
+++ b/deploy/chart/local-path-provisioner/templates/configmap.yaml
@@ -22,8 +22,13 @@ data:
   helperPod.yaml: |-
     apiVersion: v1
     kind: Pod
+    namespace: {{ default .Release.Namespace .Values.helperPod.namespaceOverride }}
     metadata:
-      name: helper-pod
+      name: {{ .Values.helperPod.name }}
+      {{- with .Values.helperPod.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       priorityClassName: system-node-critical
       tolerations:

--- a/deploy/chart/local-path-provisioner/templates/configmap.yaml
+++ b/deploy/chart/local-path-provisioner/templates/configmap.yaml
@@ -22,10 +22,10 @@ data:
   helperPod.yaml: |-
     apiVersion: v1
     kind: Pod
-    namespace: {{ default .Release.Namespace .Values.helperPod.namespaceOverride }}
+    namespace: {{ default .Release.Namespace .Values.configmap.helperPod.namespaceOverride }}
     metadata:
-      name: {{ .Values.helperPod.name }}
-      {{- with .Values.helperPod.annotations }}
+      name: {{ .Values.configmap.helperPod.name }}
+      {{- with .Values.configmap.helperPod.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -129,12 +129,11 @@ configmap:
     #!/bin/sh
     set -eu
     rm -rf "$VOL_DIR"
-
-helperPod:
-  # Allows to run the helper pod in another namespace. Uses release namespace by default.
-  namespaceOverride: ""
-  name: "helper-pod"
-  annotations: {}
+  helperPod:
+    # Allows to run the helper pod in another namespace. Uses release namespace by default.
+    namespaceOverride: ""
+    name: "helper-pod"
+    annotations: {}
 
 # Number of provisioner worker threads to call provision/delete simultaneously.
 # workerThreads: 4

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -130,6 +130,12 @@ configmap:
     set -eu
     rm -rf "$VOL_DIR"
 
+helperPod:
+  # Allows to run the helper pod in another namespace. Uses release namespace by default.
+  namespaceOverride: ""
+  name: "helper-pod"
+  annotations: {}
+
 # Number of provisioner worker threads to call provision/delete simultaneously.
 # workerThreads: 4
 


### PR DESCRIPTION
This change fixes #281 by allowing to customize specific parts of the hard coded helper pod:

- There is now the option to add annotations to the helper pod.
- You can override the pod name.
- Allow to override the namespace the helper pod runs in. By default, use the Helm release namespace.