### PR TITLE
Revert "Run the container of the helper pod in privileged mode"

### DIFF
--- a/provisioner.go
+++ b/provisioner.go
@@ -567,7 +567,6 @@ func (p *LocalPathProvisioner) createHelperPod(action ActionType, cmd []string, 
 	if o.Node != "" {
 		helperPod.Spec.NodeName = o.Node
 	}
-	privileged := true
 	helperPod.Spec.ServiceAccountName = p.serviceAccountName
 	helperPod.Spec.RestartPolicy = v1.RestartPolicyNever
 	helperPod.Spec.Tolerations = append(helperPod.Spec.Tolerations, lpvTolerations...)
@@ -578,9 +577,6 @@ func (p *LocalPathProvisioner) createHelperPod(action ActionType, cmd []string, 
 		"-s", strconv.FormatInt(o.SizeInBytes, 10),
 		"-m", string(o.Mode),
 		"-a", string(action)}
-	helperPod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{
-		Privileged: &privileged,
-	}
 
 	// If it already exists due to some previous errors, the pod will be cleaned up later automatically
 	// https://github.com/rancher/local-path-provisioner/issues/27


### PR DESCRIPTION
This reverts commit bd0bc3128029ced34de5d350befeb6a941db38f0.

https://github.com/rancher/local-path-provisioner/issues/362
https://github.com/rancher/local-path-provisioner/issues/343