### PR TITLE
feat: add support to set folderName on PVC

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,16 @@ reclaimPolicy: Delete
 
 Here the provisioner will use the path `/data/ssd` when storage class `ssd-local-path` is used.
 
+### Changing the name of the PersistentVolume
+
+By default the created folder will be `$persistentVolumeName_$persistentVolumeClaimNamespace_$persistentVolumeClaimName`.
+To specify a custom name, you can set the `volumeName` annotation on the PersistentVolumeClaim.
+
+```yaml
+annotations:
+  folderName: fooBar
+```
+
 ## Uninstall
 
 Before uninstallation, make sure the PVs created by the provisioner have already been deleted. Use `kubectl get pv` and make sure no PV with StorageClass `local-path`.

--- a/provisioner.go
+++ b/provisioner.go
@@ -285,7 +285,7 @@ func (p *LocalPathProvisioner) Provision(ctx context.Context, opts pvController.
 	}
 
 	name := opts.PVName
-	folderName := strings.Join([]string{name, opts.PVC.Namespace, opts.PVC.Name}, "_")
+	folderName := getFolderName(opts)
 
 	path := filepath.Join(basePath, folderName)
 	if nodeName == "" {
@@ -779,4 +779,11 @@ func saveHelperPodLogs(pod *v1.Pod) (err error) {
 	}
 	logrus.Infof("End of %s logs", pod.Name)
 	return nil
+}
+
+func getFolderName(opts pvController.ProvisionOptions) (folderName string) {
+	if annotationFolderName, ok := opts.PVC.GetAnnotations()["folderName"]; ok {
+		return annotationFolderName
+	}
+	return strings.Join([]string{opts.PVName, opts.PVC.Namespace, opts.PVC.Name}, "_")
 }


### PR DESCRIPTION
This makes it possible to set a 'folderName' annotation on a PVC. When set, the name of the created folder on disk will no longer be '$persistentVolumeName_$persistentVolumeClaimNamespace_$persistentVolumeClaimName'. Instead it will be overriden by the value of 'folderName' in the annotation.