### PR TITLE
Implement function to set HostPathType by annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,25 @@ annotations:
 
 A few things to note; the annotation for the `StorageClass` will apply to all volumes using it and is superseded by the annotation on the PVC if one is provided. If neither of the annotations was provided then we default to `hostPath`.
 
+### HostPath Types
+
+To specify the type of hostPath volume you want the provisioner to create, add either of the following annotations;
+
+- PVC:
+```yaml
+annotations:
+  hostPathType: <DirectoryOrCreate or Directory>
+```
+
+- StorageClass:
+```yaml
+annotations:
+  defaultHostPathType: <DirectoryOrCreate or Directory>
+```
+
+A few things to note; the annotation for the `StorageClass` will apply to all volumes using it and is superseded by the annotation on the PVC if one is provided. If neither of the annotations was provided then we default to `DirectoryOrCreate`.
+This setting will also apply to the mount type of the parent directory during provisioning.
+
 ### Storage classes
 
 If more than one `paths` are specified in the `nodePathMap` the path is chosen randomly. To make the provisioner choose a specific path, use a `storageClass` defined with a parameter called `nodePath`. Note that this path should be defined in the `nodePathMap`

--- a/examples/pod-with-host-path-type/kustomization.yaml
+++ b/examples/pod-with-host-path-type/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../pvc-with-host-path-type
+- pod.yaml

--- a/examples/pod-with-host-path-type/pod.yaml
+++ b/examples/pod-with-host-path-type/pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: volume-test
+spec:
+  containers:
+  - name: volume-test
+    image: nginx:stable-alpine
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+    - name: volv
+      mountPath: /data
+    ports:
+    - containerPort: 80
+  volumes:
+  - name: volv
+    persistentVolumeClaim:
+      claimName: local-volume-pvc

--- a/examples/pvc-with-host-path-type/kustomization.yaml
+++ b/examples/pvc-with-host-path-type/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- pvc.yaml

--- a/examples/pvc-with-host-path-type/pvc.yaml
+++ b/examples/pvc-with-host-path-type/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: local-volume-pvc
+  annotations:
+    hostPathType: Directory
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 128Mi

--- a/provisioner.go
+++ b/provisioner.go
@@ -407,14 +407,17 @@ func (p *LocalPathProvisioner) Delete(ctx context.Context, pv *v1.PersistentVolu
 		} else {
 			cleanupCmd = append(cleanupCmd, p.config.TeardownCommand)
 		}
-		if err := p.createHelperPod(ActionTypeDelete, cleanupCmd, volumeOptions{
-			Name:         pv.Name,
-			Path:         path,
-			Mode:         *pv.Spec.VolumeMode,
-			HostPathType: *pv.Spec.HostPath.Type,
-			SizeInBytes:  storage.Value(),
-			Node:         node,
-		}); err != nil {
+		volOpts := volumeOptions{
+			Name:        pv.Name,
+			Path:        path,
+			Mode:        *pv.Spec.VolumeMode,
+			SizeInBytes: storage.Value(),
+			Node:        node,
+		}
+		if pv.Spec.HostPath != nil {
+			volOpts.HostPathType = *pv.Spec.HostPath.Type
+		}
+		if err := p.createHelperPod(ActionTypeDelete, cleanupCmd, volOpts); err != nil {
 			logrus.Infof("clean up volume %v failed: %v", pv.Name, err)
 			return err
 		}

--- a/test/testdata/pod-with-default-host-path-type/kustomization.yaml
+++ b/test/testdata/pod-with-default-host-path-type/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../deploy
+- ../../../examples/pod
+patchesStrategicMerge:
+- local-path-config.yaml
+patches:
+- path: patch.yaml
+commonLabels:
+  app: local-path-provisioner
+images:
+- name: rancher/local-path-provisioner
+  newTag: dev

--- a/test/testdata/pod-with-default-host-path-type/local-path-config.yaml
+++ b/test/testdata/pod-with-default-host-path-type/local-path-config.yaml
@@ -1,0 +1,15 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+data:
+  config.json: |-
+    {
+      "nodePathMap": [
+        {
+          "node": "DEFAULT_PATH_FOR_NON_LISTED_NODES",
+          "paths": ["/tmp"]
+        }
+      ]
+    }

--- a/test/testdata/pod-with-default-host-path-type/patch.yaml
+++ b/test/testdata/pod-with-default-host-path-type/patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path
+  annotations:
+    defaultHostPathType: Directory
+provisioner: rancher.io/local-path
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/test/testdata/pod-with-host-path-type/kustomization.yaml
+++ b/test/testdata/pod-with-host-path-type/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../deploy
+- ../../../examples/pod-with-host-path-type
+patchesStrategicMerge:
+- local-path-config.yaml
+commonLabels:
+  app: local-path-provisioner
+images:
+- name: rancher/local-path-provisioner
+  newTag: dev

--- a/test/testdata/pod-with-host-path-type/local-path-config.yaml
+++ b/test/testdata/pod-with-host-path-type/local-path-config.yaml
@@ -1,0 +1,15 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+data:
+  config.json: |-
+    {
+      "nodePathMap": [
+        {
+          "node": "DEFAULT_PATH_FOR_NON_LISTED_NODES",
+          "paths": ["/tmp"]
+        }
+      ]
+    }


### PR DESCRIPTION
Implemented the function to set the PV hostPath type by annotation of StorageClass (defaultHostPathType) and PVC (hostPathType).
If neither is specified, DirectoryOrCreate is applied by default.

If the volume should not be provisioned when the parent directory does not exist, you can set the type of hostPath Directory via annotation above.

Refs rancher#137
Refs rancher#224