### PR TITLE
Helm chart: Add support for helper tolerations

### DIFF
--- a/deploy/chart/local-path-provisioner/Chart.yaml
+++ b/deploy/chart/local-path-provisioner/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Use HostPath for persistent local storage with Kubernetes
 name: local-path-provisioner
-version: 0.0.25-dev
-appVersion: "v0.0.25-dev"
+version: 0.0.26-dev
+appVersion: "v0.0.26-dev"
 keywords:
   - storage
   - hostpath

--- a/deploy/chart/local-path-provisioner/templates/configmap.yaml
+++ b/deploy/chart/local-path-provisioner/templates/configmap.yaml
@@ -30,11 +30,14 @@ data:
         - key: node.kubernetes.io/disk-pressure
           operator: Exists
           effect: NoSchedule
+      {{- with .Values.helper.tolerations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: helper-pod
           {{- if .Values.privateRegistry.registryUrl }}
-          image: {{ .Values.privateRegistry.registryUrl }}/{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}
+          image: {{ .Values.privateRegistry.registryUrl }}/{{ .Values.helper.image.repository }}:{{ .Values.helper.image.tag }}
           {{- else }}
-          image: {{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}
+          image: {{ .Values.helper.image.repository }}:{{ .Values.helper.image.tag }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/deploy/chart/local-path-provisioner/templates/deployment.yaml
+++ b/deploy/chart/local-path-provisioner/templates/deployment.yaml
@@ -51,9 +51,9 @@ spec:
             - {{ template "local-path-provisioner.provisionerName" . }}
             - --helper-image
           {{- if .Values.privateRegistry.registryUrl }}
-            - "{{ .Values.privateRegistry.registryUrl }}/{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}"
+            - "{{ .Values.privateRegistry.registryUrl }}/{{ .Values.helper.image.repository }}:{{ .Values.helper.image.tag }}"
           {{- else }}
-            - "{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}"
+            - "{{ .Values.helper.image.repository }}:{{ .Values.helper.image.tag }}"
           {{- end }}
             - --configmap-name
             - {{ .Values.configmap.name }}

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -8,9 +8,11 @@ image:
   tag: master-head
   pullPolicy: IfNotPresent
 
-helperImage:
-  repository: busybox
-  tag: latest
+helper:
+  image: 
+    repository: busybox
+    tag: latest
+  tolerations: []
 
 defaultSettings:
   registrySecret: ~


### PR DESCRIPTION
This is required if the current cluster uses tolerations for selecting certain node pools.

This change also includes the braking change to rename the .Values.helperImage to .values.helper.image, as I didn't wanted to introduce a helperTolerations top level variable.

If this is not fine, I can always revert that part of the change.