### PR TITLE
adding pvc with node name example

### DIFF
--- a/examples/pvc-with-node/kustomization.yaml
+++ b/examples/pvc-with-node/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- pvc.yaml

--- a/examples/pvc-with-node/pvc.yaml
+++ b/examples/pvc-with-node/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: local-path-pvc
+  annotations:
+    volume.kubernetes.io/selected-node: MyNode
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 128Mi


### PR DESCRIPTION
If you want to use the local path provisioner in a multi node environment, it is required to explicitly set the node name via an annotation. Unfortunally, this looks very undocumented to me. I needed to pull the right annotation label from the source code.

As minimal solution, I extended the examples with an example with a node name.

An extended version cloud also mention this in the README.