### PR TITLE
Fix: Chart.yaml file is missing on helm install

### DIFF
--- a/deploy/chart/local-path-provisioner/README.md
+++ b/deploy/chart/local-path-provisioner/README.md
@@ -11,7 +11,7 @@ solution than the built-in `local` volume feature in Kubernetes.
 ```console
 $ git clone https://github.com/rancher/local-path-provisioner.git
 $ cd local-path-provisioner
-$ helm install --name local-path-storage --namespace local-path-storage ./deploy/chart/
+$ helm install --name local-path-storage --namespace local-path-storage ./deploy/chart/local-path-provisioner
 ```
 
 ## Introduction
@@ -30,7 +30,7 @@ To install the chart with the release name `local-path-storage`:
 ```console
 $ git clone https://github.com/rancher/local-path-provisioner.git
 $ cd local-path-provisioner
-$ helm install ./deploy/chart/ --name local-path-storage --namespace local-path-storage
+$ helm install ./deploy/chart/local-path-provisioner --name local-path-storage --namespace local-path-storage
 ```
 
 The command deploys Local Path Provisioner on the Kubernetes cluster in the default configuration. The
@@ -82,14 +82,14 @@ default values.
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install ./deploy/chart/ --name local-path-storage --namespace local-path-storage --set storageClass.provisionerName=rancher.io/local-path
+$ helm install ./deploy/chart/local-path-provisioner --name local-path-storage --namespace local-path-storage --set storageClass.provisionerName=rancher.io/local-path
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the
 chart. For example,
 
 ```console
-$ helm install --name local-path-storage --namespace local-path-storage ./deploy/chart/ -f values.yaml
+$ helm install --name local-path-storage --namespace local-path-storage ./deploy/chart/local-path-provisioner -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -114,5 +114,5 @@ If the output contains "beta", you may install the chart with RBAC enabled (see 
 To enable the creation of RBAC resources (On clusters with RBAC). Do the following:
 
 ```console
-$ helm install ./deploy/chart/ --name local-path-storage --namespace local-path-storage --set rbac.create=true
+$ helm install ./deploy/chart/local-path-provisioner --name local-path-storage --namespace local-path-storage --set rbac.create=true
 ```


### PR DESCRIPTION
Add `local-path-provisioner` to `./deploy/chart` in helm install commands

Fixes #387 