### PR TITLE
Remove duplicate labels and add ability to set helperpod resource requests/limits

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/configmap.yaml
+++ b/deploy/chart/local-path-provisioner/templates/configmap.yaml
@@ -38,3 +38,6 @@ data:
           image: {{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+      resources:
+        {{- toYaml .Values.helperPod.resources | nindent 8 }}
+

--- a/deploy/chart/local-path-provisioner/templates/configmap.yaml
+++ b/deploy/chart/local-path-provisioner/templates/configmap.yaml
@@ -39,5 +39,5 @@ data:
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
-            {{- toYaml .Values.helperPod.resources | nindent 10 }}
+            {{- toYaml .Values.helperPod.resources | nindent 12 }}
 

--- a/deploy/chart/local-path-provisioner/templates/configmap.yaml
+++ b/deploy/chart/local-path-provisioner/templates/configmap.yaml
@@ -38,6 +38,6 @@ data:
           image: {{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-        resources:
-          {{- toYaml .Values.helperPod.resources | nindent 10 }}
+          resources:
+            {{- toYaml .Values.helperPod.resources | nindent 10 }}
 

--- a/deploy/chart/local-path-provisioner/templates/configmap.yaml
+++ b/deploy/chart/local-path-provisioner/templates/configmap.yaml
@@ -38,6 +38,6 @@ data:
           image: {{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-      resources:
-        {{- toYaml .Values.helperPod.resources | nindent 8 }}
+        resources:
+          {{- toYaml .Values.helperPod.resources | nindent 10 }}
 

--- a/deploy/chart/local-path-provisioner/templates/deployment.yaml
+++ b/deploy/chart/local-path-provisioner/templates/deployment.yaml
@@ -9,7 +9,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-{{ include "local-path-provisioner.labels" . | indent 6 }}
+      app.kubernetes.io/name: {{ include "local-path-provisioner.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/deploy/chart/local-path-provisioner/templates/deployment.yaml
+++ b/deploy/chart/local-path-provisioner/templates/deployment.yaml
@@ -9,8 +9,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "local-path-provisioner.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "local-path-provisioner.labels" . | indent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -18,8 +17,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app.kubernetes.io/name: {{ include "local-path-provisioner.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
 {{ include "local-path-provisioner.labels" . | indent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -102,12 +102,12 @@ resources: {}
 
 helperPod:
   resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
 
 rbac:
   # Specifies whether RBAC resources should be created

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -100,6 +100,15 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+helperPod:
+  resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
Piggybacking off this PR request from @runningman84: https://github.com/rancher/local-path-provisioner/pull/393 but retained the `selector.matchLabels` piece since it's not an immutable field after the release has been deployed and will actually block helm upgrades after the fact.

In addition to fixing the duplicate labels, this also adds the ability to add k8s resource requests/limits to the `busybox` helper-pod that's launched.

Tested this change locally in my environment and it's deploying and upgrading as expected with this flux `HelmRelease` manifest:

```
---
apiVersion: helm.toolkit.fluxcd.io/v2beta2
kind: HelmRelease
metadata:
  name: local-path-provisioner
  namespace: local-path-provisioner
spec:
  releaseName: local-path-provisioner
  interval: 10m
  chart:
    spec:
      chart: ./deploy/chart/local-path-provisioner
      version: 0.0.25-dev
      sourceRef:
        kind: GitRepository
        name: local-path-provisioner
        namespace: local-path-provisioner
      reconcileStrategy: Revision
  values:
    storageClass:
      provisionerName: local-path
    resources:
      requests:
        memory: 150Mi
        cpu: 60m
      limits:
        memory: 300Mi
        cpu: 120m
    helperPod:
      resources:
        requests:
          memory: 100Mi
          cpu: 10m
        limits:
          memory: 200Mi
          cpu: 20m

    # Number of retries of failed volume provisioning. 0 means retry indefinitely.
    provisioningRetryCount: 5
    # Number of retries of failed volume deletion. 0 means retry indefinitely.
    deletionRetryCount: 5
```