### PR TITLE
Automatic reloading of the helper pod manifest by the provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,12 @@ The scripts receive their input as environment variables:
 
 #### Reloading
 
-The provisioner supports automatic configuration reloading. Users can change the configuration using `kubectl apply` or `kubectl edit` with config map `local-path-config`. There is a delay between when the user updates the config map and the provisioner picking it up.
+The provisioner supports automatic configuration reloading. Users can change the configuration using `kubectl apply` or `kubectl edit` with config map `local-path-config`. There is a delay between when the user updates the config map and the provisioner picking it up. In order for this to occur for updates made to the helper pod manifest, the following environment variable must be added to the provisioner container. If not, then the manifest used for the helper pod will be the same as what was in the config map when the provisioner was last restarted/deployed.
+
+```yaml
+- name: CONFIG_MOUNT_PATH
+  value: /etc/config/
+```
 
 When the provisioner detects the configuration changes, it will try to load the new configuration. Users can observe it in the log
 >time="2018-10-03T05:56:13Z" level=debug msg="Applied config: {\"nodePathMap\":[{\"node\":\"DEFAULT_PATH_FOR_NON_LISTED_NODES\",\"paths\":[\"/opt/local-path-provisioner\"]},{\"node\":\"yasker-lp-dev1\",\"paths\":[\"/opt\",\"/data1\"]},{\"node\":\"yasker-lp-dev3\"}]}"

--- a/deploy/chart/local-path-provisioner/templates/deployment.yaml
+++ b/deploy/chart/local-path-provisioner/templates/deployment.yaml
@@ -72,6 +72,8 @@ spec:
           env:
             - name: POD_NAMESPACE
               value: {{ .Release.Namespace }}
+            - name: CONFIG_MOUNT_PATH
+              value: /etc/config/
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/deploy/local-path-storage.yaml
+++ b/deploy/local-path-storage.yaml
@@ -105,7 +105,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CONFIG_MOUNT_PATH
-              value: "/etc/config/"
+              value: /etc/config/
       volumes:
         - name: config-volume
           configMap:

--- a/deploy/local-path-storage.yaml
+++ b/deploy/local-path-storage.yaml
@@ -104,6 +104,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: CONFIG_MOUNT_PATH
+              value: "/etc/config/"
       volumes:
         - name: config-volume
           configMap:

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ var (
 	DefaultProvisioningRetryCount = pvController.DefaultFailedProvisionThreshold
 	FlagDeletionRetryCount        = "deletion-retry-count"
 	DefaultDeletionRetryCount     = pvController.DefaultFailedDeleteThreshold
+	EnvConfigMountPath            = "CONFIG_MOUNT_PATH"
 )
 
 func cmdNotFound(c *cli.Context, command string) {

--- a/util.go
+++ b/util.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	v1 "k8s.io/api/core/v1"
@@ -16,7 +16,7 @@ func loadFile(filepath string) (string, error) {
 		return "", err
 	}
 	defer f.Close()
-	helperPodYaml, err := ioutil.ReadAll(f)
+	helperPodYaml, err := io.ReadAll(f)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
# About

In the readme, there is a section on _reloading_ where it discusses the ability of the provisioner to be able to automatically pick up changes made to the config.

> The provisioner supports automatic configuration reloading. Users can change the configuration using kubectl apply or kubectl edit with config map local-path-config. There is a delay between when the user updates the config map and the provisioner picking it up.

I have found that, while this works for changes made to the `setup` and `teardown` scripts, when I make an update to the helper pod manifest in the config map the provisioner does not pick it up. I found that I would have to restart the provisioner for the helper pod changes to take effect.

# Changes

I have implemented a watch function of the helper pod manifest, that takes the file at the mount location (`/etc/config/`) and sets the provisioner field of `helperPod` to that of the contents of the file.

I have included a new env variable for the provisioner container that specifies the location of the config. This implementation is backwards compatible with deployments that don't have this env variable defined, as the resulting behaviour will be that of the current provisioner; meaning that changes made to the helper pod manifest in the config map will only take effect when the provisioner is restarted.

**Note:** I also updated in util to use `io.ReadAll` instead of `ioutil.ReadAll` as it was deprecated. I can change this back if it's necessary.