### PR TITLE
Allow for the configuration of shortened folder names

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ The helperPod is allowed to run on nodes experiencing disk pressure conditions, 
 `sharedFileSystemPath` allows the provisioner to use a filesystem that is mounted on all nodes at the same time.
 In this case all access modes are supported: `ReadWriteOnce`, `ReadOnlyMany` and `ReadWriteMany` for storage claims.
 
+`shortenedFolderName` takes a boolean value and provides configuration of the provisioner, allowing short folder names to be used. The default naming process is to structure it as `<PV name>-<PVC namespace>-<PVC name>`, but by specifying `"shortenedFolderName":true` the folder name will become `<PV name>`.
+
 `storageClassConfigs` is a map from storage class names to objects containing `nodePathMap` or `sharedFilesystemPath`, as described above.
 
 In addition `volumeBindingMode: Immediate` can be used in  StorageClass definition.

--- a/provisioner.go
+++ b/provisioner.go
@@ -84,6 +84,7 @@ type NodePathMapData struct {
 type StorageClassConfigData struct {
 	NodePathMap          []*NodePathMapData `json:"nodePathMap,omitempty"`
 	SharedFileSystemPath string             `json:"sharedFileSystemPath,omitempty"`
+	ShortenedFolderName  bool               `json:"shortenedFolderName,omitempty"`
 }
 
 type ConfigData struct {
@@ -97,6 +98,7 @@ type ConfigData struct {
 type StorageClassConfig struct {
 	NodePathMap          map[string]*NodePathMap
 	SharedFileSystemPath string
+	ShortenedFolderName  bool
 }
 
 type NodePathMap struct {
@@ -312,7 +314,10 @@ func (p *LocalPathProvisioner) provisionFor(opts pvController.ProvisionOptions, 
 	}
 
 	name := opts.PVName
-	folderName := strings.Join([]string{name, opts.PVC.Namespace, opts.PVC.Name}, "_")
+	folderName := name
+	if !c.ShortenedFolderName {
+		folderName = strings.Join([]string{folderName, opts.PVC.Namespace, opts.PVC.Name}, "_")
+	}
 
 	path := filepath.Join(basePath, folderName)
 	if nodeName == "" {
@@ -736,6 +741,7 @@ func canonicalizeStorageClassConfig(data *StorageClassConfigData) (cfg *StorageC
 	}()
 	cfg = &StorageClassConfig{}
 	cfg.SharedFileSystemPath = data.SharedFileSystemPath
+	cfg.ShortenedFolderName = data.ShortenedFolderName
 	cfg.NodePathMap = map[string]*NodePathMap{}
 	for _, n := range data.NodePathMap {
 		if cfg.NodePathMap[n.Node] != nil {


### PR DESCRIPTION
# Context

I use the local storage provisioner with LVM, and I have encountered a few times now where the folder being created is exceeding the [Logical Volume name length limit](https://github.com/lvmteam/lvm2/blob/25a87ea16aba335b5f33621cd5ac6ff651f0bbb1/tools/lvrename.c#L177C11-L177C20). I would like to introduce a new boolean field in the config for the provisioner called `shortenedFolderName` that, when set, creates the folder with the same name as that of the PV (aka `pvc-<uuid>`).

The default naming convention will still be the same as the current implementation (that being `<PV name>-<PVC namespace>-<PVC name>`).