### PR TITLE
drone: disable e2e test

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ steps:
   image: rancher/dapper:v0.4.2
   commands:
   - dapper ci
-  - dapper e2e-test
+  #- dapper e2e-test
   volumes:
   - name: docker
     path: /var/run/docker.sock


### PR DESCRIPTION
drone env is somehow broken. Before moving CI to GitHub Actions, disable the e2e temporarily.