### PR TITLE
e2e: wait for the provisioner to clean up PV resources

### DIFF
--- a/test/pod_test.go
+++ b/test/pod_test.go
@@ -39,6 +39,8 @@ func (p *PodTestSuite) SetupSuite() {
 	cmds := []string{
 		fmt.Sprintf("kind create cluster --config=%s --wait=120s", testdataFile("kind-cluster.yaml")),
 		fmt.Sprintf("kind load docker-image %s", p.config.IMAGE),
+		// We'll be replacing this, but applying particular labels to it.
+		"kubectl -n local-path-storage delete deployment local-path-provisioner --wait",
 	}
 	for _, cmd := range cmds {
 		_, err = runCmd(

--- a/test/testdata/custom-path-pattern/kustomization.yaml
+++ b/test/testdata/custom-path-pattern/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../../deploy
+- ../labelled-deploy
 - storage-class.yaml
 - pod.yaml
 - pvc.yaml

--- a/test/testdata/labelled-deploy/kustomization.yaml
+++ b/test/testdata/labelled-deploy/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../deploy
+commonLabels:
+  system-component: "true"

--- a/test/testdata/multiple-storage-classes/kustomization.yaml
+++ b/test/testdata/multiple-storage-classes/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../../deploy
+- ../labelled-deploy
 - storage-class-shared.yaml
 - pod.yaml
 - pvc.yaml

--- a/test/testdata/pod-with-default-local-volume/kustomization.yaml
+++ b/test/testdata/pod-with-default-local-volume/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../../deploy
+- ../labelled-deploy
 - ../../../examples/pod
 patches:
 - path: patch.yaml

--- a/test/testdata/pod-with-local-volume/kustomization.yaml
+++ b/test/testdata/pod-with-local-volume/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../../deploy
+- ../labelled-deploy
 - ../../../examples/pod-with-local-volume
 commonLabels:
   app: local-path-provisioner

--- a/test/testdata/pod-with-node-affinity/kustomization.yaml
+++ b/test/testdata/pod-with-node-affinity/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../../deploy
+- ../labelled-deploy
 - ../../../examples/pod-with-node-affinity
 patches:
 - path: patch.yaml

--- a/test/testdata/pod-with-rwop-volume/kustomization.yaml
+++ b/test/testdata/pod-with-rwop-volume/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../../deploy
+- ../labelled-deploy
 - ../../../examples/pod-with-rwop-volume
 commonLabels:
   app: local-path-provisioner

--- a/test/testdata/pod-with-security-context/kustomization.yaml
+++ b/test/testdata/pod-with-security-context/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../../deploy
+- ../labelled-deploy
 - ../../../examples/pod-with-security-context
 commonLabels:
   app: local-path-provisioner

--- a/test/testdata/pod-with-subpath/kustomization.yaml
+++ b/test/testdata/pod-with-subpath/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../../deploy
+- ../labelled-deploy
 - ../../../examples/pod-with-subpath
 commonLabels:
   app: local-path-provisioner

--- a/test/testdata/pod/kustomization.yaml
+++ b/test/testdata/pod/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../../deploy
+- ../labelled-deploy
 - ../../../examples/pod
 commonLabels:
   app: local-path-provisioner


### PR DESCRIPTION
If we're unlucky, the local-path-provisioner can be killed before it has a chance to clean up orphened PVs. These may then hang around while subsequent tests run. Depending on the lexical sort order of those PVs, the `typeCheckCmd` in `runTest` may select a moribund PV, causing the test to randomly fail.