### PR TITLE
Add support for Block devices

### DIFF
--- a/provisioner.go
+++ b/provisioner.go
@@ -281,6 +281,10 @@ func (p *LocalPathProvisioner) isSharedFilesystem(c *StorageClassConfig) (bool, 
 	return false, fmt.Errorf("both nodePathMap and sharedFileSystemPath are unconfigured")
 }
 
+func (p *LocalPathProvisioner) SupportsBlock(_ context.Context) bool {
+	return true
+}
+
 func (p *LocalPathProvisioner) pickConfig(storageClassName string) (*StorageClassConfig, error) {
 	if len(p.config.StorageClassConfigs) == 0 {
 		return &p.config.StorageClassConfig, nil
@@ -399,8 +403,6 @@ func (p *LocalPathProvisioner) provisionFor(opts pvController.ProvisionOptions, 
 		return nil, pvController.ProvisioningFinished, err
 	}
 
-	fs := v1.PersistentVolumeFilesystem
-
 	var pvs v1.PersistentVolumeSource
 	var volumeType string
 	if dVal, ok := opts.StorageClass.GetAnnotations()["defaultVolumeType"]; ok {
@@ -452,7 +454,7 @@ func (p *LocalPathProvisioner) provisionFor(opts pvController.ProvisionOptions, 
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeReclaimPolicy: *opts.StorageClass.ReclaimPolicy,
 			AccessModes:                   pvc.Spec.AccessModes,
-			VolumeMode:                    &fs,
+			VolumeMode:                    pvc.Spec.VolumeMode,
 			Capacity: v1.ResourceList{
 				v1.ResourceStorage: pvc.Spec.Resources.Requests[v1.ResourceStorage],
 			},


### PR DESCRIPTION
Following up to #125 and after #127 has been merged, it should be up to the helper Pod to decide up on support for Block devices or not.

In fact i have it running with the scripts from #125

But to create the ressources the PV that gets created needs to inherit the correct volumeMode and block support should be allowed.