### PR TITLE
Revert "Give the helper pod more range of MCS categories"

### DIFF
--- a/provisioner.go
+++ b/provisioner.go
@@ -674,11 +674,7 @@ func (p *LocalPathProvisioner) createHelperPod(action ActionType, cmd []string, 
 		"-s", strconv.FormatInt(o.SizeInBytes, 10),
 		"-m", string(o.Mode),
 		"-a", string(action)}
-	helperPod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{
-		SELinuxOptions: &v1.SELinuxOptions{
-			Level: "s0-s0:c0.c1023",
-		},
-	}
+
 	// If it already exists due to some previous errors, the pod will be cleaned up later automatically
 	// https://github.com/rancher/local-path-provisioner/issues/27
 	logrus.Infof("create the helper pod %s into %s", helperPod.Name, p.namespace)


### PR DESCRIPTION
This reverts commit c4dc309a6b28794f9c6fae6cdbbca9411d521847.

Hello @galal-hussein 

According to @js185692 feedback, the PR you contributed overrides the value in the configmap. 
You can apply the [solution](https://github.com/rancher/local-path-provisioner/issues/420#issuecomment-2166006104) instead. 
