### PR TITLE
chart: fix helm chart version + appVersion reference

### DIFF
--- a/deploy/chart/local-path-provisioner/Chart.yaml
+++ b/deploy/chart/local-path-provisioner/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Use HostPath for persistent local storage with Kubernetes
 name: local-path-provisioner
-version: master-head
-appVersion: "master-head"
+version: 0.0.28
+appVersion: "v0.0.28"
 keywords:
   - storage
   - hostpath

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -5,7 +5,7 @@ commonLabels: {}
 
 image:
   repository: rancher/local-path-provisioner
-  tag: master-head
+  tag: v0.0.28
   pullPolicy: IfNotPresent
 
 helperImage:


### PR DESCRIPTION
Fixes: https://github.com/rancher/local-path-provisioner/issues/436

i've omitted the "v" in version, as it would not be valid SemVer 2.