### PR TITLE
Update lib versions on vendor modules.txt

### DIFF
--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -129,10 +129,10 @@ github.com/stretchr/testify/suite
 # github.com/urfave/cli v1.19.1
 ## explicit
 github.com/urfave/cli
-# golang.org/x/crypto v0.14.0
+# golang.org/x/crypto v0.25.0
 ## explicit; go 1.17
 golang.org/x/crypto/ed25519
-# golang.org/x/net v0.17.0
+# golang.org/x/net v0.27.0
 ## explicit; go 1.17
 golang.org/x/net/bpf
 golang.org/x/net/context
@@ -148,15 +148,15 @@ golang.org/x/net/ipv6
 ## explicit; go 1.17
 golang.org/x/oauth2
 golang.org/x/oauth2/internal
-# golang.org/x/sys v0.13.0
+# golang.org/x/sys v0.22.0
 ## explicit; go 1.17
 golang.org/x/sys/plan9
 golang.org/x/sys/unix
 golang.org/x/sys/windows
-# golang.org/x/term v0.13.0
+# golang.org/x/term v0.22.0
 ## explicit; go 1.17
 golang.org/x/term
-# golang.org/x/text v0.13.0
+# golang.org/x/text v0.16.0
 ## explicit; go 1.17
 golang.org/x/text/secure/bidirule
 golang.org/x/text/transform
@@ -174,7 +174,7 @@ google.golang.org/appengine/internal/log
 google.golang.org/appengine/internal/remote_api
 google.golang.org/appengine/internal/urlfetch
 google.golang.org/appengine/urlfetch
-# google.golang.org/protobuf v1.31.0
+# google.golang.org/protobuf v1.34.2
 ## explicit; go 1.11
 google.golang.org/protobuf/encoding/prototext
 google.golang.org/protobuf/encoding/protowire


### PR DESCRIPTION
This PR updates the go module versions within the vendor modules. 

This fixes the broken builds on the master branch following the golang version updated delivered under https://github.com/rancher/local-path-provisioner/commit/ed8fd34ae7dd9078bd6419c01871610d91c4ba13