### PR TITLE
add: specify nodePath in storageclass

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/storageclass.yaml
+++ b/deploy/chart/local-path-provisioner/templates/storageclass.yaml
@@ -20,10 +20,15 @@ provisioner: {{ template "local-path-provisioner.provisionerName" $dot }}
 volumeBindingMode: {{ $values.storageClass.volumeBindingMode }}
 reclaimPolicy: {{ $values.storageClass.reclaimPolicy }}
 allowVolumeExpansion: true
-{{- if $values.storageClass.pathPattern }}
+{{- if or $values.storageClass.nodePath $values.storageClass.pathPattern }}
 parameters:
+  {{- if $values.storageClass.pathPattern }}
   pathPattern: {{ $values.storageClass.pathPattern | quote }}
-{{  end -}}
+  {{- end }}
+  {{- if $values.storageClass.nodePath }}
+  nodePath: {{ $values.storageClass.nodePath | quote }}
+  {{- end }}
+{{- end }}
 {{- end }}
 ---
 {{- end }}

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -51,6 +51,10 @@ storageClass:
   ## Set a path pattern, if unset the default will be used
   # pathPattern: "{{ .PVC.Namespace }}-{{ .PVC.Name }}"
 
+  ## Set a node path, or choose the value in nodePathMap if it is not set
+  ## nodePath must be in nodePathMap
+  # nodePath: "/opt/local-path-provisioner"
+
 # nodePathMap is the place user can customize where to store the data on each node.
 # 1. If one node is not listed on the nodePathMap, and Kubernetes wants to create volume on it, the paths specified in
 #    DEFAULT_PATH_FOR_NON_LISTED_NODES will be used for provisioning.


### PR DESCRIPTION
## Description
helm supports configuring nodePath when creating storageclass.

Use Cases:
When the default configuration in `nodePathMap` has multiple paths, it is expected that the default sc can use the specified path.