### PR TITLE
Check data persistence after pod deletion

### DIFF
--- a/test/pod_test.go
+++ b/test/pod_test.go
@@ -16,8 +16,8 @@ import (
 const (
 	hostPathVolumeType = "hostPath"
 	localVolumeType    = "local"
-    normalDataPath     = "/data"
-    subPathDataPath    = "/nginx"
+	normalDataPath     = "/data"
+	subPathDataPath    = "/nginx"
 )
 
 type PodTestSuite struct {
@@ -210,7 +210,6 @@ func runTest(p *PodTestSuite, images []string, waitCondition, volumeType string)
 	}
 }
 
-
 func runPersistenceTest(p *PodTestSuite, images []string, dataPath string) {
 	kustomizeDir := testdataFile(p.kustomizeDir)
 
@@ -223,9 +222,9 @@ func runPersistenceTest(p *PodTestSuite, images []string, dataPath string) {
 
 	cmds = append(
 		cmds,
-	    fmt.Sprintf("kubectl exec volume-test -- sh -c 'echo foo > %s/bar'", dataPath),
-	    "kubectl delete pod/volume-test",
-	    "kubectl wait --for=delete pod/volume-test --timeout=120s",
+		fmt.Sprintf("kubectl exec volume-test -- sh -c 'echo foo > %s/bar'", dataPath),
+		"kubectl delete pod/volume-test",
+		"kubectl wait --for=delete pod/volume-test --timeout=120s",
 		"kustomize build | kubectl apply -f -",
 		"kubectl wait pod volume-test --for condition=ready --timeout=120s",
 	)
@@ -248,7 +247,7 @@ func runPersistenceTest(p *PodTestSuite, images []string, dataPath string) {
 	c := createCmd(p.T(), catDataCmd, kustomizeDir, p.config.envs(), nil)
 	catDataOutput, err := c.CombinedOutput()
 	if err != nil {
-        p.FailNow("", "failed to cat 'bar' from %s: %v", dataPath, err)
+		p.FailNow("", "failed to cat 'bar' from %s: %v", dataPath, err)
 	}
 
 	if len(catDataOutput) == 0 || !strings.Contains(string(catDataOutput), "foo") {


### PR DESCRIPTION
Correct me if I'm wrong, but, properly speaking, there's no test checking that data is actually persisted after pod deletion.

I created this test bc I'm facing an issue on `talos` with `local-path-provisioner`:  when mounting a PV  and using the `subPath` directive, the PV is not mounted at the right location, and thus data is lost when pod deleted.

I can't reproduce it with Kind and this test suite, so I guess the issue is with `talos`, and not with this project. However, what about adding this test anyway ? 