### PR TITLE
fix: helm install command

### DIFF
--- a/deploy/chart/local-path-provisioner/README.md
+++ b/deploy/chart/local-path-provisioner/README.md
@@ -30,7 +30,7 @@ To install the chart with the release name `local-path-storage`:
 ```console
 $ git clone https://github.com/rancher/local-path-provisioner.git
 $ cd local-path-provisioner
-$ helm install ./deploy/chart/local-path-provisioner --name local-path-storage --namespace local-path-storage
+$ helm install local-path-storage --create-namespace --namespace local-path-storage ./deploy/chart/local-path-provisioner/
 ```
 
 The command deploys Local Path Provisioner on the Kubernetes cluster in the default configuration. The


### PR DESCRIPTION
I just ran across this issue:

```
helm install ./deploy/chart/local-path-provisioner --name local-path-storage --namespace local-path-storage
Error: unknown flag: --name
```

My PR updates the command to install the local-path-provisioner:

```
helm install local-path-storage --create-namespace --namespace local-path-storage ./deploy/chart/local-path-provisioner/
NAME: local-path-storage
LAST DEPLOYED: Tue Dec 10 12:01:52 2024
NAMESPACE: local-path-storage
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
You can create a hostpath-backed persistent volume with a persistent volume claim like this:

apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: local-path-pvc
spec:
  accessModes:
    - ReadWriteOnce
  storageClassName: local-path
  resources:
    requests:
      storage: 2Gi
```

My helm version is v3.16.3.