### PR TITLE
fix: don't try to clean up pvs on nodes that are gone

### DIFF
--- a/provisioner.go
+++ b/provisioner.go
@@ -486,6 +486,11 @@ func (p *LocalPathProvisioner) deleteFor(pv *v1.PersistentVolume, c *StorageClas
 		if node == "" {
 			logrus.Infof("Deleting volume %v at %v", pv.Name, path)
 		} else {
+			// Check if node still exists
+			if _, err := p.kubeClient.CoreV1().Nodes().Get(context.TODO(), node, metav1.GetOptions{}); err != nil && k8serror.IsNotFound(err) {
+				logrus.Infof("Node %v does not exist, skipping cleanup of volume %v", node, pv.Name)
+				return nil
+			}
 			logrus.Infof("Deleting volume %v at %v:%v", pv.Name, node, path)
 		}
 		storage := pv.Spec.Capacity[v1.ResourceName(v1.ResourceStorage)]


### PR DESCRIPTION
We're running local-provisioner to provide local storage for CI runners where nodes come and go pretty frequently.
We observe that the provisioner is trying run clean up on nodes that are already gone, which causes helper pods
to be stuck in pending state as they cannot be scheduled.

This PR adds a check to see if the node still exists before trying to clean up the node.
