### PR TITLE
Fix helper pod tolerations

### DIFF
--- a/provisioner.go
+++ b/provisioner.go
@@ -602,7 +602,9 @@ func (p *LocalPathProvisioner) createHelperPod(action ActionType, cmd []string, 
 	}
 	lpvTolerations := []v1.Toleration{
 		{
+			Key:      v1.TaintNodeDiskPressure,
 			Operator: v1.TolerationOpExists,
+			Effect:   v1.TaintEffectNoSchedule,
 		},
 	}
 	helperPod := p.helperPod.DeepCopy()

--- a/provisioner.go
+++ b/provisioner.go
@@ -666,7 +666,9 @@ func (p *LocalPathProvisioner) createHelperPod(action ActionType, cmd []string, 
 	}
 	helperPod.Spec.ServiceAccountName = p.serviceAccountName
 	helperPod.Spec.RestartPolicy = v1.RestartPolicyNever
-	helperPod.Spec.Tolerations = append(helperPod.Spec.Tolerations, lpvTolerations...)
+	if helperPod.Spec.Tolerations == nil {
+		helperPod.Spec.Tolerations = append(helperPod.Spec.Tolerations, lpvTolerations...)
+	}
 	helperPod.Spec.Volumes = append(helperPod.Spec.Volumes, lpvVolumes...)
 	helperPod.Spec.Containers[0].Command = cmd
 	helperPod.Spec.Containers[0].Env = append(helperPod.Spec.Containers[0].Env, env...)


### PR DESCRIPTION
Currently, helperPod tolerates any taints as the provisioner always adds `- operator: Exists` toleration to the helperPod spec. This toleration is extremely permissive, defeating the purpose of setting extra helperPod tolerations through the config. 

This PR address the issue with the following:
1. Do not apply the default tolerations if helperPod tolerations are provided through the config
2. Replace the extremely permissive toleration with:
```
tolerations:
  - key: node.kubernetes.io/disk-pressure
    operator: Exists
    effect: NoSchedule
```

that's already used across majority of the helper-pod examples, assuming it's as a sane new default.

Fixes https://github.com/rancher/local-path-provisioner/issues/487