### PR TITLE
Build local-path-provisioner for ppc64le

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -3,7 +3,7 @@
 FROM alpine
 
 ARG TARGETPLATFORM
-RUN if [ "$TARGETPLATFORM" != "linux/amd64" ] && [ "$TARGETPLATFORM" != "linux/arm64" ] && [ "$TARGETPLATFORM" != "linux/arm/v7" ] && [ "$TARGETPLATFORM" != "linux/riscv64" ]; then \
+RUN if [ "$TARGETPLATFORM" != "linux/amd64" ] && [ "$TARGETPLATFORM" != "linux/arm64" ] && [ "$TARGETPLATFORM" != "linux/arm/v7" ] && [ "$TARGETPLATFORM" != "linux/ppc64le" ] && [ "$TARGETPLATFORM" != "linux/riscv64" ]; then \
     echo "Error: Unsupported TARGETPLATFORM: $TARGETPLATFORM" && \
     exit 1; \
     fi

--- a/scripts/build
+++ b/scripts/build
@@ -13,6 +13,7 @@ LINKFLAGS="-X main.VERSION=$VERSION"
 CGO_ENABLED=0 GOARCH=amd64 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/local-path-provisioner-amd64
 CGO_ENABLED=0 GOARCH=arm64 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/local-path-provisioner-arm64
 CGO_ENABLED=0 GOARCH=arm go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/local-path-provisioner-arm
+CGO_ENABLED=0 GOARCH=ppc64le go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/local-path-provisioner-ppc64le
 CGO_ENABLED=0 GOARCH=riscv64 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/local-path-provisioner-riscv64
 if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
     GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/local-path-provisioner-darwin


### PR DESCRIPTION
This PR includes changes to build local-path-provisioner for the PowerPC (ppc64le) architecture.
Referred https://github.com/rancher/local-path-provisioner/pull/447 for making required changes to support building for a new arch.