### PR TITLE
fix: do not override nodeName, if exists

### DIFF
--- a/provisioner.go
+++ b/provisioner.go
@@ -661,7 +661,7 @@ func (p *LocalPathProvisioner) createHelperPod(action ActionType, cmd []string, 
 		helperPod.Name = helperPod.Name[:HelperPodNameMaxLength]
 	}
 	helperPod.Namespace = p.namespace
-	if o.Node != "" {
+	if helperPod.Spec.NodeName == "" && o.Node != "" {
 		helperPod.Spec.NodeName = o.Node
 	}
 	helperPod.Spec.ServiceAccountName = p.serviceAccountName


### PR DESCRIPTION
If nodeName was already provided in helperPod.yaml, avoid overriding it. Fixes #498