### PR TITLE
Allow overriding kubeclient burst and qps settings

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/deployment.yaml
+++ b/deploy/chart/local-path-provisioner/templates/deployment.yaml
@@ -67,6 +67,9 @@ spec:
             - --deletion-retry-count
             - {{ .Values.deletionRetryCount | quote }}
           {{- end }}
+          {{- range .Values.extraArgs }}
+            - {{ . }}
+          {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config/

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -92,13 +92,15 @@ nodePathMap:
 #     ## OR
 #     # See above
 #     nodePathMap: {}
-    
+
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # runAsNonRoot: true
 
-securityContext: {}
+securityContext:
+  {}
   # allowPrivilegeEscalation: false
   # seccompProfile:
   #   type: RuntimeDefault
@@ -108,7 +110,8 @@ securityContext: {}
   # runAsGroup: 65534
   # readOnlyRootFilesystem: true
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -121,7 +124,8 @@ resources: {}
   #   memory: 128Mi
 
 helperPod:
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -174,3 +178,6 @@ configmap:
 
 # Number of retries of failed volume deletion. 0 means retry indefinitely.
 # deletionRetryCount: 15
+
+# Extra arguments to pass to the CLI
+extraArgs: []

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -92,15 +92,13 @@ nodePathMap:
 #     ## OR
 #     # See above
 #     nodePathMap: {}
-
+    
 podAnnotations: {}
 
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # runAsNonRoot: true
 
-securityContext:
-  {}
+securityContext: {}
   # allowPrivilegeEscalation: false
   # seccompProfile:
   #   type: RuntimeDefault
@@ -110,8 +108,7 @@ securityContext:
   # runAsGroup: 65534
   # readOnlyRootFilesystem: true
 
-resources:
-  {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -124,8 +121,7 @@ resources:
   #   memory: 128Mi
 
 helperPod:
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi

--- a/main.go
+++ b/main.go
@@ -49,6 +49,8 @@ var (
 	FlagDeletionRetryCount        = "deletion-retry-count"
 	DefaultDeletionRetryCount     = pvController.DefaultFailedDeleteThreshold
 	EnvConfigMountPath            = "CONFIG_MOUNT_PATH"
+	FlagKubeClientBurst           = "kube-client-burst"
+	FlagKubeClientQPS             = "kube-client-qps"
 )
 
 func cmdNotFound(_ *cli.Context, command string) {
@@ -132,6 +134,16 @@ func StartCmd() cli.Command {
 				Usage: "Number of retries of failed volume deletion. 0 means retry indefinitely.",
 				Value: DefaultDeletionRetryCount,
 			},
+			cli.IntFlag{
+				Name:  FlagKubeClientBurst,
+				Usage: "Burst value for kubernetes client.",
+				Value: rest.DefaultBurst,
+			},
+			cli.Float64Flag{
+				Name:  FlagKubeClientQPS,
+				Usage: "QPS value for kubernetes client.",
+				Value: float64(rest.DefaultQPS),
+			},
 		},
 		Action: func(c *cli.Context) {
 			if err := startDaemon(c); err != nil {
@@ -191,6 +203,8 @@ func startDaemon(c *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to get client config")
 	}
+	config.Burst = c.Int(FlagKubeClientBurst)
+	config.QPS = float32(c.Float64(FlagKubeClientQPS))
 
 	kubeClient, err := clientset.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
We are running into rate limits and need a way to configure the client burst and qps settings.

In our use case, we spin up GitLab and GitHub jobs in their own pods. It's not uncommon for a job to kick off multiple downstream jobs, each of which needs a PVC. Once the client-side limit is reached, jobs begin queueing, resulting in a poor experience for our users.

This PR allows overriding these settings from the defaults.

It looks like we aren’t the only ones who need to adjust these settings — see #417.