### PR TITLE
Change default nodePathMap value in storageClassConfigs in values.yml to []

### DIFF
--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -91,7 +91,7 @@ nodePathMap:
 #     sharedFileSystemPath: ""
 #     ## OR
 #     # See above
-#     nodePathMap: {}
+#     nodePathMap: []
     
 podAnnotations: {}
 


### PR DESCRIPTION
Small fix in values.yml of chart

Because nodePathMap is an array and not an object