### PR TITLE
Helm: Add abbility to set additional tolerations to helper pod via values

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/configmap.yaml
+++ b/deploy/chart/local-path-provisioner/templates/configmap.yaml
@@ -49,6 +49,9 @@ data:
         - key: node.kubernetes.io/disk-pressure
           operator: Exists
           effect: NoSchedule
+        {{- with .Values.configmap.helperPod.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: helper-pod
           {{- if .Values.privateRegistry.registryUrl }}

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -166,6 +166,7 @@ configmap:
     namespaceOverride: ""
     name: "helper-pod"
     annotations: {}
+    tolerations: []
 # Number of provisioner worker threads to call provision/delete simultaneously.
 # workerThreads: 4
 


### PR DESCRIPTION
A PR #377 has already been opened in the repository, but unfortunately, it was not completed.
I would like to add the ability to specify additional tolerations for the Helper Pod via the chart’s values.