### PR TITLE
Add common labels to helperPod config map template

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/configmap.yaml
+++ b/deploy/chart/local-path-provisioner/templates/configmap.yaml
@@ -43,6 +43,8 @@ data:
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      labels:
+{{ include "local-path-provisioner.labels" . | indent 8 }}
     spec:
       priorityClassName: system-node-critical
       tolerations:


### PR DESCRIPTION
This update adds standard chart labels to the helperPod.yaml manifest within the ConfigMap to ensure consistency with other resources. No functional behavior of the helper pod is altered beyond enhanced metadata for resource management.

<img width="1746" height="502" alt="image" src="https://github.com/user-attachments/assets/db017883-7136-4d37-b90b-b662e6c86bad" />