### PR TITLE
add storageClass.allowedTopologies in helm chart

### DIFF
--- a/deploy/chart/local-path-provisioner/README.md
+++ b/deploy/chart/local-path-provisioner/README.md
@@ -65,6 +65,8 @@ default values.
 | `storageClass.defaultVolumeType`    | The default volume type this storage class creates                              | `hostPath`                                                                          |
 | `storageClass.name`                 | The name to assign the created StorageClass                                     | local-path                                                                          |
 | `storageClass.reclaimPolicy`        | ReclaimPolicy field of the class                                                | Delete                                                                              |
+| `storageClass.volumeBindingMode`    | volumeBindingMode field of the class                                            | `WaitForFirstConsumer`                                                              |
+| `storageClass.allowedTopologies`    | allowedTopologies field of the class                                            | `[]`                                                                                |
 | `storageClass.pathPattern`          | Template for the volume directory name                                          | `nil`                                                                               |
 | `nodePathMap`                       | Configuration of where to store the data on each node                           | `[{node: DEFAULT_PATH_FOR_NON_LISTED_NODES, paths: [/opt/local-path-provisioner]}]` |
 | `resources`                         | Local Path Provisioner resource requests & limits                               | `{}`                                                                                |

--- a/deploy/chart/local-path-provisioner/templates/storageclass.yaml
+++ b/deploy/chart/local-path-provisioner/templates/storageclass.yaml
@@ -20,10 +20,14 @@ provisioner: {{ template "local-path-provisioner.provisionerName" $dot }}
 volumeBindingMode: {{ $values.storageClass.volumeBindingMode }}
 reclaimPolicy: {{ $values.storageClass.reclaimPolicy }}
 allowVolumeExpansion: true
+{{- if $values.storageClass.allowedTopologies }}
+allowedTopologies:
+{{ toYaml $values.storageClass.allowedTopologies | indent 0 }}
+{{- end }}
 {{- if $values.storageClass.pathPattern }}
 parameters:
   pathPattern: {{ $values.storageClass.pathPattern | quote }}
-{{  end -}}
+{{- end }}
 {{- end }}
 ---
 {{- end }}

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -49,6 +49,9 @@ storageClass:
   ## volumeBindingMode field controls when volume binding and dynamic provisioning should occur, can be  "Immediate" or "WaitForFirstConsumer"
   volumeBindingMode: WaitForFirstConsumer
 
+  ## allowedTopologies field controls on which nodes the volumes can be dynamically provisioned, an empty value means no topology constraints
+  allowedTopologies: []
+
   ## Set a path pattern, if unset the default will be used
   # pathPattern: "{{ .PVC.Namespace }}-{{ .PVC.Name }}"
 


### PR DESCRIPTION
support `allowedTopologies` as we have dedicated node pool for local path storage.
example:
```yaml
  ## allowedTopologies field controls on which nodes the volumes can be dynamically provisioned, an empty value means no topology constraints
  allowedTopologies:
  - matchLabelExpressions:
    - key: example.com/local-ssd
      values:
      - "true"
```