### PR TITLE
feat: add priorityClassName support for provisioner and helper pods

### DIFF
--- a/deploy/chart/local-path-provisioner/README.md
+++ b/deploy/chart/local-path-provisioner/README.md
@@ -74,6 +74,8 @@ default values.
 | `nodeSelector`                      | Node labels for Local Path Provisioner pod assignment                           | `{}`                                                                                |
 | `tolerations`                       | Node taints to tolerate                                                         | `[]`                                                                                |
 | `affinity`                          | Pod affinity                                                                    | `{}`                                                                                |
+| `priorityClassName`                 | Priority class name for the main provisioner pod                               | `""`                                                                                |
+| `configmap.helperPod.priorityClassName` | Priority class name for the helper pod                                    | `"system-node-critical"`                                                           |
 | `configmap.setup`                   | Configuration of script to execute setup operations on each node                | #!/bin/sh<br>while getopts "m:s:p:" opt<br>do<br>&emsp;case $opt in <br>&emsp;&emsp;p)<br>&emsp;&emsp;absolutePath=$OPTARG<br>&emsp;&emsp;;;<br>&emsp;&emsp;s)<br>&emsp;&emsp;sizeInBytes=$OPTARG<br>&emsp;&emsp;;;<br>&emsp;&emsp;m)<br>&emsp;&emsp;volMode=$OPTARG<br>&emsp;&emsp;;;<br>&emsp;esac<br>done<br>mkdir -m 0777 -p ${absolutePath}                                    |
 | `configmap.teardown`                | Configuration of script to execute teardown operations on each node             | #!/bin/sh<br>while getopts "m:s:p:" opt<br>do<br>&emsp;case $opt in <br>&emsp;&emsp;p)<br>&emsp;&emsp;absolutePath=$OPTARG<br>&emsp;&emsp;;;<br>&emsp;&emsp;s)<br>&emsp;&emsp;sizeInBytes=$OPTARG<br>&emsp;&emsp;;;<br>&emsp;&emsp;m)<br>&emsp;&emsp;volMode=$OPTARG<br>&emsp;&emsp;;;<br>&emsp;esac<br>done<br>rm -rf ${absolutePath}                                              |
 | `configmap.name`                    | configmap name                                                                  | `local-path-config`                                                                 |
@@ -84,6 +86,18 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```console
 $ helm install ./deploy/chart/local-path-provisioner --name local-path-storage --namespace local-path-storage --set storageClass.provisionerName=rancher.io/local-path
+```
+
+To set a priority class for the provisioner pod:
+
+```console
+$ helm install ./deploy/chart/local-path-provisioner --name local-path-storage --namespace local-path-storage --set priorityClassName=high-priority
+```
+
+To set different priority classes for both main and helper pods:
+
+```console
+$ helm install ./deploy/chart/local-path-provisioner --name local-path-storage --namespace local-path-storage --set priorityClassName=high-priority --set configmap.helperPod.priorityClassName=system-cluster-critical
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the

--- a/deploy/chart/local-path-provisioner/templates/configmap.yaml
+++ b/deploy/chart/local-path-provisioner/templates/configmap.yaml
@@ -44,7 +44,9 @@ data:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      priorityClassName: system-node-critical
+      {{- if .Values.configmap.helperPod.priorityClassName }}
+      priorityClassName: {{ .Values.configmap.helperPod.priorityClassName }}
+      {{- end }}
       tolerations:
         - key: node.kubernetes.io/disk-pressure
           operator: Exists

--- a/deploy/chart/local-path-provisioner/templates/deployment.yaml
+++ b/deploy/chart/local-path-provisioner/templates/deployment.yaml
@@ -25,6 +25,9 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ template "local-path-provisioner.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -146,6 +146,9 @@ tolerations: []
 
 affinity: {}
 
+# Priority class name for the pod
+priorityClassName: ""
+
 podDisruptionBudget:
   enabled: false
 
@@ -167,6 +170,8 @@ configmap:
     name: "helper-pod"
     annotations: {}
     tolerations: []
+    # Priority class name for the helper pod (defaults to system-node-critical)
+    priorityClassName: "system-node-critical"
 # Number of provisioner worker threads to call provision/delete simultaneously.
 # workerThreads: 4
 


### PR DESCRIPTION
## Description

This PR adds support for configuring `priorityClassName` for both the main provisioner pod and helper pods in the local-path-provisioner Helm chart. Previously, users could not set priority classes for these critical storage infrastructure components, limiting their ability to properly prioritize pods in resource-constrained environments.

## Changes

- Added `priorityClassName` field to `values.yaml` for the main provisioner pod
- Added `configmap.helperPod.priorityClassName` field to `values.yaml` for helper pods
- Modified `templates/deployment.yaml` to conditionally render `priorityClassName` when specified
- Updated `templates/configmap.yaml` to make helper pod priority configurable (was hard-coded to `system-node-critical`)
- Enhanced documentation in `README.md` with configuration examples and parameter descriptions

## Usage Scenarios

- **Main pod priority only**: Set `priorityClassName` to assign priority to the main provisioner deployment
- **Helper pod priority only**: Set `configmap.helperPod.priorityClassName` to assign priority to volume operation pods
- **Both pod priorities**: Configure both fields to have different priority classes for different pod types
- **No priority classes**: Leave both fields empty to maintain current behavior (helper pod defaults to `system-node-critical`)

## Example

```yaml
# Main provisioner pod priority
priorityClassName: "high-priority"

# Helper pod priority (for volume operations)
configmap:
  helperPod:
    priorityClassName: "system-cluster-critical"
```

Or via command line:
```bash
helm install local-path-storage . \
  --set priorityClassName=high-priority \
  --set configmap.helperPod.priorityClassName=system-cluster-critical
```

## Testing

- Verified that priority classes are correctly applied when specified in values
- Confirmed that no `priorityClassName` field is rendered when values are empty
- Ensured helper pod maintains `system-node-critical` default when not overridden
- Tested both individual and combined priority class configurations
- All existing functionality remains backward compatible

## Backward Compatibility

This change is fully backward compatible. All existing configurations will continue to work as before, with helper pods maintaining their default `system-node-critical` priority class when not explicitly configured.
