### PR TITLE
fix(chart): correct ServiceAccount namespace in ClusterRoleBinding

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/clusterrolebinding.yaml
+++ b/deploy/chart/local-path-provisioner/templates/clusterrolebinding.yaml
@@ -12,5 +12,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "local-path-provisioner.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "local-path-provisioner.namespace" . }}
 {{- end -}}


### PR DESCRIPTION
Update the clusterrolebinding.yaml to use
`{{ include "local-path-provisioner.namespace" . }}` so the ClusterRoleBinding correctly references the ServiceAccount in the intended Namespace when `namespaceOverride` is set.

The `namespaceOverride` feauture was added in the commit 772344504a9b ("feat: add ability to set custom namespace"), but the namespace of the ServiceAccount subject in the ClusterRoleBinding was not updated accordingly. As a result, it continued to use
`{{ .Release.Namespace }}`, causing permission errors when a custom namespace was specified.