### PR TITLE
fix: give clusterrole update on pvc

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/clusterrole.yaml
+++ b/deploy/chart/local-path-provisioner/templates/clusterrole.yaml
@@ -7,8 +7,11 @@ metadata:
 {{ include "local-path-provisioner.labels" . | indent 4 }}
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods", "pods/log"]
+    resources: ["nodes", "configmaps", "pods", "pods/log"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]


### PR DESCRIPTION
When provisioning fails, the controller tries to remove the selected node annotation to allow reprovisioning:
<https://github.com/rancher/local-path-provisioner/blob/58a077d589c04c95f1720a78b9618ebe8e2abea8/vendor/sigs.k8s.io/sig-storage-lib-external-provisioner/v11/controller/controller.go#L1388>
But this fails with an RBAC error due to lack of permissions
