### PR TITLE
Add support for s390x architecture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
       with:
         context: ./
         push: true
-        platforms: linux/amd64,linux/arm64,linux/arm,linux/riscv64
+        platforms: linux/amd64,linux/arm64,linux/arm,linux/riscv64,linux/s390x
         tags: rancher/local-path-provisioner:${{ env.branch }}-head
         file: package/Dockerfile
 
@@ -98,6 +98,6 @@ jobs:
       with:
         context: ./
         push: true
-        platforms: linux/amd64,linux/arm64,linux/arm,linux/riscv64
+        platforms: linux/amd64,linux/arm64,linux/arm,linux/riscv64,linux/s390x
         tags: rancher/local-path-provisioner:${{ github.ref_name }}
         file: package/Dockerfile

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -3,7 +3,7 @@
 FROM alpine
 
 ARG TARGETPLATFORM
-RUN if [ "$TARGETPLATFORM" != "linux/amd64" ] && [ "$TARGETPLATFORM" != "linux/arm64" ] && [ "$TARGETPLATFORM" != "linux/arm/v7" ] && [ "$TARGETPLATFORM" != "linux/ppc64le" ] && [ "$TARGETPLATFORM" != "linux/riscv64" ]; then \
+RUN if [ "$TARGETPLATFORM" != "linux/amd64" ] && [ "$TARGETPLATFORM" != "linux/arm64" ] && [ "$TARGETPLATFORM" != "linux/arm/v7" ] && [ "$TARGETPLATFORM" != "linux/ppc64le" ] && [ "$TARGETPLATFORM" != "linux/riscv64" ] && [ "$TARGETPLATFORM" != "linux/s390x" ]; then \
     echo "Error: Unsupported TARGETPLATFORM: $TARGETPLATFORM" && \
     exit 1; \
     fi

--- a/scripts/build
+++ b/scripts/build
@@ -15,6 +15,7 @@ CGO_ENABLED=0 GOARCH=arm64 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bi
 CGO_ENABLED=0 GOARCH=arm go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/local-path-provisioner-arm
 CGO_ENABLED=0 GOARCH=ppc64le go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/local-path-provisioner-ppc64le
 CGO_ENABLED=0 GOARCH=riscv64 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/local-path-provisioner-riscv64
+CGO_ENABLED=0 GOARCH=s390x go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/local-path-provisioner-s390x
 if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
     GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/local-path-provisioner-darwin
     GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/local-path-provisioner-windows


### PR DESCRIPTION
This PR includes changes to build local-path-provisioner and add s390x architecture to the GitHub Actions CI. 