### PR TITLE
feat: optional networkPolicy for local-path-provisioner

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/networkpolicy.yaml
+++ b/deploy/chart/local-path-provisioner/templates/networkpolicy.yaml
@@ -4,6 +4,8 @@ kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-network-policy" (include "local-path-provisioner.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ include "local-path-provisioner.namespace" . }}
+  labels:
+{{ include "local-path-provisioner.labels" . | indent 4 }}
 spec:
   egress:
     {{- with .Values.networkPolicy.egress }}
@@ -15,9 +17,8 @@ spec:
     {{- end }}
   podSelector:
     matchLabels:
-       app.kubernetes.io/name: {{ include "local-path-provisioner.name" . }}
-       app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ include "local-path-provisioner.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   policyTypes:
-  - Egress
-  - Ingress
+    {{- toYaml .Values.networkPolicy.policyTypes | nindent 4 }}
 {{- end }}

--- a/deploy/chart/local-path-provisioner/templates/networkpolicy.yaml
+++ b/deploy/chart/local-path-provisioner/templates/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-network-policy" (include "local-path-provisioner.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ include "local-path-provisioner.namespace" . }}
+spec:
+  egress:
+    {{- with .Values.networkPolicy.egress }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  ingress:
+    {{- with .Values.networkPolicy.ingress }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  podSelector:
+    matchLabels:
+       app.kubernetes.io/name: {{ include "local-path-provisioner.name" . }}
+       app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+  - Egress
+  - Ingress
+{{- end }}

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -115,6 +115,9 @@ hostUsers: true
 networkPolicy:
   # -- Specifies whether the networkPolicy should be created.
   enabled: false
+  # -- The policy types to enforce.
+  policyTypes:
+  - Egress
   # -- The ingress traffic
   # Should match the health and (optionally) metrics port
   ingress: []

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -111,6 +111,30 @@ podSecurityContext: {}
 
 hostUsers: true
 
+# `networkPolicy` allows you to define acceptable network traffic
+networkPolicy:
+  # -- Specifies whether the networkPolicy should be created.
+  enabled: false
+  # -- The ingress traffic
+  # Should match the health and (optionally) metrics port
+  ingress: []
+  # -- The egress traffic
+  # The minimum egress ports required to function are:
+  #   DNS (53/udp, 53/tcp)
+  #   API server (80/tcp, 443/tcp, 6443/tcp) NOTE: OKD and Openshift use 6443/tcp
+  egress:
+  - ports:
+    - port: 80
+      protocol: TCP
+    - port: 443
+      protocol: TCP
+    - port: 53
+      protocol: TCP
+    - port: 53
+      protocol: UDP
+    - port: 6443
+      protocol: TCP
+
 securityContext: {}
   # allowPrivilegeEscalation: false
   # seccompProfile:


### PR DESCRIPTION
This is a super simple networkpolicy, but should provide a workable starting point for folks who want something more advanced.

I'd love it if there was some sort of metrics/health/readiness/etc probes. But since there aren't any, just drop ingress...