### PR TITLE
Grant helper pod only the priv it needs, explicitly set root bits

### DIFF
--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -101,20 +101,24 @@ nodePathMap:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # runAsNonRoot: true
+podSecurityContext:
+  runAsNonRoot: true
 
 hostUsers: true
 
-securityContext: {}
-  # allowPrivilegeEscalation: false
-  # seccompProfile:
-  #   type: RuntimeDefault
-  # capabilities:
-  #   drop: ["ALL"]
-  # runAsUser: 65534
-  # runAsGroup: 65534
-  # readOnlyRootFilesystem: true
+# NOTE: launches a helper pod with hostPath volume
+#       thus namespace must permit PSS privileged.
+#       Last checked on kubernetes 1.35
+securityContext:
+  allowPrivilegeEscalation: false
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop:
+      - ALL
+  runAsUser: 65534
+  runAsGroup: 65534
+  readOnlyRootFilesystem: true
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -184,6 +188,26 @@ configmap:
     tolerations: []
     # Priority class name for the helper pod (defaults to system-node-critical)
     priorityClassName: "system-node-critical"
+    # Should the users map to system IDs
+    hostUsers: true
+    # pod level security controls
+    securityContext:
+      runAsNonRoot: false
+    # container level security controls
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      privileged: false
+      capabilities:
+        drop:
+        - ALL
+        add:  # explicitly add the only capability we actually use
+        - DAC_OVERRIDE
+      readOnlyRootFilesystem: true
+      runAsGroup: 0
+      runAsUser: 0
+      seccompProfile:
+        type: RuntimeDefault
+#
 # Number of provisioner worker threads to call provision/delete simultaneously.
 # workerThreads: 4
 


### PR DESCRIPTION
This adds settings to the `helper-pod` so it has its security controls defined and setup explicitly.

With these in place it appears possible to run the main deployment as a fully non-root instance.