### PR TITLE
feat: allow setting securityContext on helper pods.

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/configmap.yaml
+++ b/deploy/chart/local-path-provisioner/templates/configmap.yaml
@@ -66,3 +66,7 @@ data:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.helperPod.resources | nindent 12 }}
+          {{- with .Values.configmap.helperPod.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -182,6 +182,7 @@ configmap:
     name: "helper-pod"
     annotations: {}
     tolerations: []
+    securityContext: {}
     # Priority class name for the helper pod (defaults to system-node-critical)
     priorityClassName: "system-node-critical"
 # Number of provisioner worker threads to call provision/delete simultaneously.


### PR DESCRIPTION
# Changes
Small change to the helm chart to allow setting `securityContext` on the helper pods. 

# Why
In order for the helper pod to delete the contents of the PV, `runAsUser` or `priveleged` might be needed under the securityContext of the container.

# Testing
Tested on a bare metal cluster (using `runAsUser: 0` to allow deleting the contents of a PV that had been populated with data)