### PR TITLE
Build linux/ppc64le images through build on GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
       with:
         context: ./
         push: true
-        platforms: linux/amd64,linux/arm64,linux/arm,linux/riscv64,linux/s390x
+        platforms: linux/amd64,linux/arm64,linux/arm,linux/ppc64le,linux/riscv64,linux/s390x
         tags: rancher/local-path-provisioner:${{ env.branch }}-head
         file: package/Dockerfile
 
@@ -98,6 +98,6 @@ jobs:
       with:
         context: ./
         push: true
-        platforms: linux/amd64,linux/arm64,linux/arm,linux/riscv64,linux/s390x
+        platforms: linux/amd64,linux/arm64,linux/arm,linux/ppc64le,linux/riscv64,linux/s390x
         tags: rancher/local-path-provisioner:${{ github.ref_name }}
         file: package/Dockerfile


### PR DESCRIPTION
This PR contains changes to enable building of the local-path-provisioner image through GitHub Actions build workflow for `ppc64le`. 

The supporting changes to build the binaries were added through #492.

Thank you.