### PR TITLE
Support exposing user, group and perm patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,9 @@ The scripts receive their input as environment variables:
 | `VOL_DIR` | Volume directory that should be created or removed. |
 | `VOL_MODE` | The PersistentVolume mode (`Block` or `Filesystem`). |
 | `VOL_SIZE_BYTES` | Requested volume size in bytes. |
-| `VOL_USER` | The user assigned from `userPattern` |
-| `VOL_GROUP` | The group assigned from `groupPattern` |
-| `VOL_PERM` | The permissions assigned from `permPattern` |
+| `VOL_USER` | User rendered from `userPattern`. |
+| `VOL_GROUP` | Group rendered from `groupPattern`. |
+| `VOL_PERM` | Permissions rendered from `permPattern`. |
 
 #### Reloading
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ The scripts receive their input as environment variables:
 | `VOL_DIR` | Volume directory that should be created or removed. |
 | `VOL_MODE` | The PersistentVolume mode (`Block` or `Filesystem`). |
 | `VOL_SIZE_BYTES` | Requested volume size in bytes. |
+| `VOL_USER` | The user assigned from `userPattern` |
+| `VOL_GROUP` | The group assigned from `groupPattern` |
+| `VOL_PERM` | The permissions assigned from `permPattern` |
 
 #### Reloading
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ By default the volume subdirectory is named using the template `{{ .PVName }}_{{
 
 When `pathPattern` is set, the rendered path must start with `{{ .PVC.Namespace }}/{{ .PVC.Name }}/` and must not contain directory traversal (for example `../`).
 
+The patterns of `userPattern`, `groupPattern` and `permPattern` (either in `parameters` or `metadata.annotations`) can be used to set user, group, permissions of the volume's directory based on data in the PVC.  These are set to `$VOL_USER`, `$VOL_GROUP` and `$VOL_PERM` in the startup script.
+
 If you need to keep an existing `pathPattern` that does not follow the prefix requirement, you can opt out by setting `allowUnsafePathPattern: "true"` on the StorageClass (either in `parameters` or `metadata.annotations`). When enabled, the provisioner will skip these validations.
 ```
 apiVersion: storage.k8s.io/v1

--- a/deploy/chart/local-path-provisioner/templates/storageclass.yaml
+++ b/deploy/chart/local-path-provisioner/templates/storageclass.yaml
@@ -27,13 +27,22 @@ allowVolumeExpansion: true
 allowedTopologies:
 {{ toYaml $values.storageClass.allowedTopologies | indent 0 }}
 {{- end }}
-{{- if or $values.storageClass.pathPattern $values.storageClass.nodeAffinityKey }}
+{{- if or $values.storageClass.pathPattern $values.storageClass.nodeAffinityKey $values.storageClass.userPattern $values.storageClass.groupPattern $values.storageClass.permPattern }}
 parameters:
   {{- if $values.storageClass.pathPattern }}
   pathPattern: {{ $values.storageClass.pathPattern | quote }}
   {{- end }}
   {{- if $values.storageClass.nodeAffinityKey }}
   nodeAffinityKey: {{ $values.storageClass.nodeAffinityKey | quote }}
+  {{- end }}
+  {{- if $values.storageClass.userPattern }}
+  userPattern: {{ $values.storageClass.userPattern | quote }}
+  {{- end }}
+  {{- if $values.storageClass.groupPattern }}
+  groupPattern: {{ $values.storageClass.groupPattern | quote }}
+  {{- end }}
+  {{- if $values.storageClass.permPattern }}
+  permPattern: {{ $values.storageClass.permPattern | quote }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -63,6 +63,15 @@ storageClass:
   ## the default `kubernetes.io/hostname` behavior is preserved.
   # nodeAffinityKey: my.domain/stable-node-id
 
+  ## Set a user pattern
+  userPattern: ''
+
+  ## Set a group pattern
+  groupPattern: ''
+
+  ## Set a permission pattern
+  permPattern: ''
+
 # nodePathMap is the place user can customize where to store the data on each node.
 # 1. If one node is not listed on the nodePathMap, and Kubernetes wants to create volume on it, the paths specified in
 #    DEFAULT_PATH_FOR_NON_LISTED_NODES will be used for provisioning.

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -69,7 +69,7 @@ storageClass:
   ## Set a group pattern
   groupPattern: ''
 
-  ## Set a permission pattern
+  ## Set a permission pattern (string). Quote numeric modes to preserve leading zeros (e.g. '0700').
   permPattern: ''
 
 # nodePathMap is the place user can customize where to store the data on each node.

--- a/provisioner.go
+++ b/provisioner.go
@@ -56,7 +56,10 @@ const (
 )
 
 const (
-	nodeNameAnnotationKey = "local.path.provisioner/selected-node"
+	nodeNameAnnotationKey     = "local.path.provisioner/selected-node"
+	userPatternAnnotationKey  = "userPattern"
+	groupPatternAnnotationKey = "groupPattern"
+	permPatternAnnotationKey  = "permPattern"
 )
 
 var (
@@ -452,6 +455,9 @@ func (p *LocalPathProvisioner) provisionFor(opts pvController.ProvisionOptions, 
 	}
 	var user, group, perm string
 	userPattern, exists := opts.StorageClass.Parameters["userPattern"]
+	if !exists {
+		userPattern, exists = opts.StorageClass.GetAnnotations()[userPatternAnnotationKey]
+	}
 	if exists {
 		user, err = dataFromPattern(userPattern, opts)
 		if err != nil {
@@ -460,6 +466,9 @@ func (p *LocalPathProvisioner) provisionFor(opts pvController.ProvisionOptions, 
 		}
 	}
 	groupPattern, exists := opts.StorageClass.Parameters["groupPattern"]
+	if !exists {
+		groupPattern, exists = opts.StorageClass.GetAnnotations()[groupPatternAnnotationKey]
+	}
 	if exists {
 		group, err = dataFromPattern(groupPattern, opts)
 		if err != nil {
@@ -468,6 +477,9 @@ func (p *LocalPathProvisioner) provisionFor(opts pvController.ProvisionOptions, 
 		}
 	}
 	permPattern, exists := opts.StorageClass.Parameters["permPattern"]
+	if !exists {
+		permPattern, exists = opts.StorageClass.GetAnnotations()[permPatternAnnotationKey]
+	}
 	if exists {
 		perm, err = dataFromPattern(permPattern, opts)
 		if err != nil {

--- a/provisioner.go
+++ b/provisioner.go
@@ -344,7 +344,7 @@ func dataFromPattern(pattern string, opts pvController.ProvisionOptions) (string
 		PVC:    opts.PVC.ObjectMeta,
 	}
 
-	tpl, err := template.New("dataPattern").Parse(pattern)
+	tpl, err := template.New("dataPattern").Option("missingkey=error").Parse(pattern)
 	if err != nil {
 		return "", err
 	}
@@ -355,7 +355,7 @@ func dataFromPattern(pattern string, opts pvController.ProvisionOptions) (string
 		return "", err
 	}
 
-	return buf.String(), nil
+	return strings.TrimSpace(buf.String()), nil
 }
 
 func (p *LocalPathProvisioner) Provision(_ context.Context, opts pvController.ProvisionOptions) (*v1.PersistentVolume, pvController.ProvisioningState, error) {

--- a/provisioner.go
+++ b/provisioner.go
@@ -42,9 +42,12 @@ const (
 	helperDataVolName   = "data"
 	helperScriptVolName = "script"
 
-	envVolDir  = "VOL_DIR"
-	envVolMode = "VOL_MODE"
-	envVolSize = "VOL_SIZE_BYTES"
+	envVolDir   = "VOL_DIR"
+	envVolMode  = "VOL_MODE"
+	envVolSize  = "VOL_SIZE_BYTES"
+	envVolUser  = "VOL_USER"
+	envVolGroup = "VOL_GROUP"
+	envVolPerm  = "VOL_PERM"
 )
 
 const (
@@ -332,6 +335,26 @@ func pathFromPattern(pattern string, opts pvController.ProvisionOptions, allowUn
 	return path, nil
 }
 
+func dataFromPattern(pattern string, opts pvController.ProvisionOptions) (string, error) {
+	metadata := pvMetadata{
+		PVName: opts.PVName,
+		PVC:    opts.PVC.ObjectMeta,
+	}
+
+	tpl, err := template.New("dataPattern").Parse(pattern)
+	if err != nil {
+		return "", err
+	}
+
+	buf := new(bytes.Buffer)
+	err = tpl.Execute(buf, metadata)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
 func (p *LocalPathProvisioner) Provision(_ context.Context, opts pvController.ProvisionOptions) (*v1.PersistentVolume, pvController.ProvisioningState, error) {
 	cfg, err := p.pickConfig(opts.StorageClass.Name)
 	if err != nil {
@@ -427,12 +450,40 @@ func (p *LocalPathProvisioner) provisionFor(opts pvController.ProvisionOptions, 
 	} else {
 		provisionCmd = append(provisionCmd, p.config.SetupCommand)
 	}
+	var user, group, perm string
+	userPattern, exists := opts.StorageClass.Parameters["userPattern"]
+	if exists {
+		user, err = dataFromPattern(userPattern, opts)
+		if err != nil {
+			err = errors.Wrapf(err, "failed to create user from pattern %v", userPattern)
+			return nil, pvController.ProvisioningFinished, err
+		}
+	}
+	groupPattern, exists := opts.StorageClass.Parameters["groupPattern"]
+	if exists {
+		group, err = dataFromPattern(groupPattern, opts)
+		if err != nil {
+			err = errors.Wrapf(err, "failed to create group from pattern %v", groupPattern)
+			return nil, pvController.ProvisioningFinished, err
+		}
+	}
+	permPattern, exists := opts.StorageClass.Parameters["permPattern"]
+	if exists {
+		perm, err = dataFromPattern(permPattern, opts)
+		if err != nil {
+			err = errors.Wrapf(err, "failed to create perm from pattern %v", permPattern)
+			return nil, pvController.ProvisioningFinished, err
+		}
+	}
 	if err := p.createHelperPod(ActionTypeCreate, provisionCmd, volumeOptions{
 		Name:        name,
 		Path:        path,
 		Mode:        *pvc.Spec.VolumeMode,
 		SizeInBytes: storage.Value(),
 		Node:        nodeName,
+		User:        user,
+		Group:       group,
+		Perm:        perm,
 	}, c); err != nil {
 		return nil, pvController.ProvisioningFinished, err
 	}
@@ -619,6 +670,9 @@ type volumeOptions struct {
 	Mode        v1.PersistentVolumeMode
 	SizeInBytes int64
 	Node        string
+	User        string
+	Group       string
+	Perm        string
 }
 
 func (p *LocalPathProvisioner) createHelperPod(action ActionType, cmd []string, o volumeOptions, cfg *StorageClassConfig) (err error) {
@@ -703,6 +757,9 @@ func (p *LocalPathProvisioner) createHelperPod(action ActionType, cmd []string, 
 		{Name: envVolDir, Value: filepath.Join(parentDir, volumeDir)},
 		{Name: envVolMode, Value: string(o.Mode)},
 		{Name: envVolSize, Value: strconv.FormatInt(o.SizeInBytes, 10)},
+		{Name: envVolUser, Value: o.User},
+		{Name: envVolGroup, Value: o.Group},
+		{Name: envVolPerm, Value: o.Perm},
 	}
 
 	// use different name for helper pods


### PR DESCRIPTION
This is still untested but the idea is to allow the setup command to be this:

```
install -d -u $VOL_USER -g $VOL_GROUP -m $VOL_PERM $VOL_DIR
```

We are overloading local-path-provisioner to allow PVC storage onto our cluster filesystems and having root:root and 0777 on a shared resource is far from ideal especially when we sometimes deal with very sensitive data on our clusters where a 0777 directory behind a 0700 directory still raises red flags.

Fixes #610