### PR TITLE
helm: make debug logging configurable via values

### DIFF
--- a/deploy/chart/local-path-provisioner/Chart.yaml
+++ b/deploy/chart/local-path-provisioner/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Use HostPath for persistent local storage with Kubernetes
 name: local-path-provisioner
-version: 0.0.35
+version: 0.0.36
 appVersion: "v0.0.35"
 keywords:
   - storage

--- a/deploy/chart/local-path-provisioner/templates/deployment.yaml
+++ b/deploy/chart/local-path-provisioner/templates/deployment.yaml
@@ -43,7 +43,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - local-path-provisioner
+            {{- if .Values.debug }}
             - --debug
+            {{- end }}
             - start
             - --config
             - /etc/config/config.json

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -193,5 +193,8 @@ configmap:
 # Number of retries of failed volume deletion. 0 means retry indefinitely.
 # deletionRetryCount: 15
 
+# Enable debug logging
+debug: false
+
 # Extra arguments to pass to the CLI
 extraArgs: []


### PR DESCRIPTION
## Summary

The Helm chart currently hard-codes `--debug` in the container command, forcing verbose logging in all environments with no way to disable it.

This PR:
- Adds a `debug` value to `values.yaml` (defaults to `false`)
- Wraps the `--debug` flag in a conditional in `deployment.yaml`
- Bumps the chart version to `0.0.36`

With this change, users can opt into debug logging when needed:

```yaml
# values.yaml
debug: true
```

Closes #556