### PR TITLE
chart: add optional SELinux node-setup DaemonSet

### DIFF
--- a/deploy/chart/local-path-provisioner/templates/selinux-node-setup.yaml
+++ b/deploy/chart/local-path-provisioner/templates/selinux-node-setup.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.seLinuxNodeSetup.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "local-path-provisioner.fullname" . }}-node-setup
+  namespace: {{ include "local-path-provisioner.namespace" . }}
+  labels:
+{{ include "local-path-provisioner.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "local-path-provisioner.name" . }}-node-setup
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "local-path-provisioner.name" . }}-node-setup
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      initContainers:
+        - name: selinux-setup
+          image: "{{ .Values.seLinuxNodeSetup.image.repository }}:{{ .Values.seLinuxNodeSetup.image.tag }}"
+          imagePullPolicy: {{ .Values.seLinuxNodeSetup.image.pullPolicy }}
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              {{- range .Values.seLinuxNodeSetup.paths }}
+              mkdir -p /host{{ . }}
+              chcon -Rt {{ $.Values.seLinuxNodeSetup.seLinuxType }} /host{{ . }}
+              {{- end }}
+          volumeMounts:
+            - name: host-root
+              mountPath: /host
+      containers:
+        - name: pause
+          image: "{{ .Values.seLinuxNodeSetup.image.repository }}:{{ .Values.seLinuxNodeSetup.image.tag }}"
+          imagePullPolicy: {{ .Values.seLinuxNodeSetup.image.pullPolicy }}
+          command: ["sh", "-c", "trap 'exit 0' TERM; sleep infinity & wait"]
+          securityContext:
+            privileged: true
+      volumes:
+        - name: host-root
+          hostPath:
+            path: /
+      tolerations:
+        - operator: Exists
+{{- end }}

--- a/deploy/chart/local-path-provisioner/values.yaml
+++ b/deploy/chart/local-path-provisioner/values.yaml
@@ -101,6 +101,24 @@ nodePathMap:
 
 podAnnotations: {}
 
+# seLinuxNodeSetup deploys a privileged DaemonSet that labels storage paths
+# with the correct SELinux context so that helper pods can write to them.
+# Required on SELinux-enforcing nodes (e.g. RKE2 on RHEL/SUSE) where the
+# provisioner paths under /opt/local-path-provisioner would otherwise be
+# inaccessible to containers (AVC denial on write/create).
+seLinuxNodeSetup:
+  enabled: false
+  image:
+    repository: busybox
+    tag: latest
+    pullPolicy: IfNotPresent
+  # SELinux type to apply to each path. container_file_t allows any
+  # container process to read and write the labeled directory.
+  seLinuxType: container_file_t
+  # Paths to label. Should match the paths configured in nodePathMap.
+  paths:
+    - /opt/local-path-provisioner
+
 podSecurityContext: {}
   # runAsNonRoot: true
 


### PR DESCRIPTION
## Problem

On SELinux-enforcing nodes (e.g. RKE2 on RHEL/SUSE), the local-path-provisioner helper pods fail to create or delete volumes because the storage paths (e.g. `/opt/local-path-provisioner`) carry the wrong SELinux label. The helper pod's `container_t` process is denied write access by SELinux, so PVC provisioning silently fails.

The workaround today requires manual intervention on every node:

```bash
zypper -n in policycoreutils-python-utils
semanage fcontext -a -t container_file_t "/opt/local-path-provisioner(/.*)?"
restorecon -R -v /opt/local-path-provisioner/
```

This must be repeated for every new node that joins the cluster.

## Solution

Add an opt-in DaemonSet (`seLinuxNodeSetup.enabled=true`) that runs a privileged init container on every node to:

1. Create the storage path if it does not exist (`mkdir -p`).
2. Apply `chcon -Rt container_file_t` (or any configured SELinux type) to label it, allowing container processes to read and write it.

The DaemonSet tolerates all taints so it reaches every node, including control-plane nodes. The label is re-applied each time the pod starts, covering nodes that join the cluster after initial deployment.

The feature is **disabled by default** — no change for non-SELinux environments.

## Usage

```yaml
seLinuxNodeSetup:
  enabled: true
  paths:
    - /opt/local-path-provisioner   # match your nodePathMap paths
```

## Test plan

- [ ] Deploy chart with `seLinuxNodeSetup.enabled=false` (default) on a non-SELinux cluster — no DaemonSet created, no regression
- [ ] Deploy chart with `seLinuxNodeSetup.enabled=true` on an RKE2 cluster (RHEL/SUSE, SELinux enforcing) — DaemonSet runs on all nodes, labels the path, PVC provisioning succeeds without manual intervention
- [ ] Add a new node to the cluster — node-setup pod starts automatically and labels the path before any workload is scheduled