### PR TITLE
fix: use alpine as base image for package/Dockerfile to avoid shippin…

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7.0
 
-FROM golang:1.26.3-alpine
+FROM alpine
 
 ARG TARGETPLATFORM
 ARG TARGETARCH


### PR DESCRIPTION
Regression introduced in bdd23d0b (chore: use registry.suse.com/bci/golang),
which replaced the minimal alpine base with a golang-based image in the
production Dockerfile. Since the binary is already statically built in the
CI Dockerfile stage, the runtime image doesn't need Go installed — this
bloated the final image from ~64MB to ~297MB (~4.6x).
